### PR TITLE
mds scrub fix

### DIFF
--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1555,3 +1555,27 @@ options:
   - mds
   flags:
   - runtime
+- name: mds_damage_log_to_file
+  type: bool
+  level: advanced
+  desc: send mds damage lines to a file
+  fmt_desc: Determines if damages should appear in a file.
+  default: false
+  see_also:
+  - log_file
+  with_legacy: true
+- name: mds_damage_log_file
+  type: str
+  level: advanced
+  desc: path to log file where damage will be written
+  fmt_desc: The location of the logging file for where damage of mds will be written.
+  daemon_default: /var/log/ceph/$cluster-$name-damages.log
+  with_legacy: true
+- name: mds_scrub_hard_link
+  type: bool
+  level: advanced
+  desc: force scrubbing hard link
+  default: false
+  services:
+  - mds
+  with_legacy: true

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -483,7 +483,8 @@ public:
   void fetch(MDSContext *c, bool ignore_authpinnability=false) {
     fetch("", CEPH_NOSNAP, c, ignore_authpinnability);
   }
-  void fetch_keys(const std::vector<dentry_key_t>& keys, MDSContext *c);
+  void fetch_keys(const std::vector<dentry_key_t> &keys, MDSContext *c,
+                  bool from_scrub = false);
 
 #if 0  // unused?
   void wait_for_commit(Context *c, version_t v=0);
@@ -653,7 +654,8 @@ protected:
   friend class C_IO_Dir_Committed;
   friend class C_IO_Dir_Commit_Ops;
 
-  void _omap_fetch(std::set<std::string> *keys, MDSContext *fin=nullptr);
+  void _omap_fetch(std::set<std::string> *keys, MDSContext *fin = nullptr,
+                   bool from_scrub = false);
   void _omap_fetch_more(version_t omap_version, bufferlist& hdrbl,
 			std::map<std::string, bufferlist>& omap, MDSContext *fin);
   CDentry *_load_dentry(
@@ -671,8 +673,10 @@ protected:
    */
   void go_bad(bool complete);
 
-  void _omap_fetched(ceph::buffer::list& hdrbl, std::map<std::string, ceph::buffer::list>& omap,
-		     bool complete, const std::set<std::string>& keys, int r);
+  void _omap_fetched(ceph::buffer::list &hdrbl,
+                     std::map<std::string, ceph::buffer::list> &omap,
+                     bool complete, const std::set<std::string> &keys, int r,
+                     bool from_scrub = false);
 
   // -- commit --
   void _commit(version_t want, int op_prio);

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -305,6 +305,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
     bool last_scrub_dirty = false; /// are our stamps dirty with respect to disk state?
     bool scrub_in_progress = false; /// are we currently scrubbing?
+    std::vector<std::pair<std::string, inodeno_t>> remote_links;
+    bool forward_scrub = true;
 
     fragset_t queued_frags;
 
@@ -457,6 +459,15 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void scrub_finished();
 
   void scrub_aborted();
+
+  void scrub_add_remote_link(
+      std::vector<std::pair<std::string, inodeno_t>> &&remote_links);
+
+  void scrub_reset_remote_links();
+
+  std::vector<std::pair<std::string, inodeno_t>> &&scrub_move_remote_links();
+
+  void set_forward_scrub(bool forward_scrub);
 
   fragset_t& scrub_queued_frags() {
     ceph_assert(scrub_infop);

--- a/src/mds/DamageTable.cc
+++ b/src/mds/DamageTable.cc
@@ -29,6 +29,12 @@ namespace {
  * Record damage to a particular dirfrag, implicitly affecting
  * any dentries within it.
  */
+inline std::ostream& operator<<(std::ostream& os, const DamageEntry& entry)
+{
+  entry.print(os);
+  return os;
+}
+
 class DirFragDamage : public DamageEntry
 {
   public:
@@ -123,6 +129,28 @@ class BacktraceDamage : public DamageEntry
     f->close_section();
   }
 };
+
+class RemoteLinkDamage : public DamageEntry {
+public:
+  inodeno_t ino;
+  std::string head_path;
+  RemoteLinkDamage(inodeno_t ino_, const std::string &head_path_ = "")
+      : ino(ino_), head_path(head_path_) {}
+
+  damage_entry_type_t get_type() const override {
+    return DAMAGE_ENTRY_REMOTE_LINK;
+  }
+
+  void dump(Formatter *f) const override {
+    f->open_object_section("remote_link_damage");
+    f->dump_string("damage_type", "remote_link");
+    f->dump_int("id", id);
+    f->dump_int("ino", ino);
+    f->dump_string("path", path);
+    f->dump_string("head_path", head_path);
+    f->close_section();
+  }
+};
 }
 
 DamageEntry::~DamageEntry()
@@ -132,28 +160,34 @@ bool DamageTable::notify_dentry(
     inodeno_t ino, frag_t frag,
     snapid_t snap_id, std::string_view dname, std::string_view path)
 {
-  if (oversized()) {
+  bool over_sized = oversized();
+  if (!log_to_file && over_sized) {
     return true;
   }
 
   // Special cases: damage to these dirfrags is considered fatal to
   // the MDS rank that owns them.
-  if (
-      (MDS_INO_IS_MDSDIR(ino) && MDS_INO_MDSDIR_OWNER(ino) == rank)
-      ||
-      (MDS_INO_IS_STRAY(ino) && MDS_INO_STRAY_OWNER(ino) == rank)
-     ) {
+  if ((MDS_INO_IS_MDSDIR(ino) && MDS_INO_MDSDIR_OWNER(ino) == rank) ||
+      (MDS_INO_IS_STRAY(ino) && MDS_INO_STRAY_OWNER(ino) == rank)) {
     derr << "Damage to dentries in fragment " << frag << " of ino " << ino
          << "is fatal because it is a system directory for this rank" << dendl;
     return true;
   }
 
-  auto& df_dentries = dentries[DirFragIdent(ino, frag)];
-  if (auto [it, inserted] = df_dentries.try_emplace(DentryIdent(dname, snap_id)); inserted) {
-    auto entry = std::make_shared<DentryDamage>(ino, frag, dname, snap_id);
-    entry->path = path;
-    it->second = entry;
-    by_id[entry->id] = std::move(entry);
+  auto entry = std::make_shared<DentryDamage>(ino, frag, dname, snap_id);
+  entry->path = path;
+  if (log_to_file) {
+    fout << *entry << std::endl;
+  }
+
+  if (!over_sized) {
+    auto &df_dentries = dentries[DirFragIdent(ino, frag)];
+    if (auto [it, inserted] =
+            df_dentries.try_emplace(DentryIdent(dname, snap_id));
+        inserted) {
+      it->second = entry;
+      by_id[entry->id] = std::move(entry);
+    }
   }
 
   return false;
@@ -171,15 +205,24 @@ bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag,
     return true;
   }
 
-  if (oversized()) {
+  bool over_sized = oversized();
+
+  if (!log_to_file && over_sized) {
     return true;
   }
 
-  if (auto [it, inserted] = dirfrags.try_emplace(DirFragIdent(ino, frag)); inserted) {
-    DamageEntryRef entry = std::make_shared<DirFragDamage>(ino, frag);
-    entry->path = path;
-    it->second = entry;
-    by_id[entry->id] = std::move(entry);
+  DamageEntryRef entry = std::make_shared<DirFragDamage>(ino, frag);
+  entry->path = path;
+  if (log_to_file) {
+    fout << *entry << std::endl;
+  }
+
+  if (!over_sized) {
+    if (auto [it, inserted] = dirfrags.try_emplace(DirFragIdent(ino, frag));
+        inserted) {
+      it->second = entry;
+      by_id[entry->id] = std::move(entry);
+    }
   }
 
   return false;
@@ -187,15 +230,47 @@ bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag,
 
 bool DamageTable::notify_remote_damaged(inodeno_t ino, std::string_view path)
 {
-  if (oversized()) {
+  bool over_sized = oversized();
+  if (!log_to_file && over_sized) {
     return true;
   }
 
-  if (auto [it, inserted] = remotes.try_emplace(ino); inserted) {
-    auto entry = std::make_shared<BacktraceDamage>(ino);
-    entry->path = path;
-    it->second = entry;
-    by_id[entry->id] = std::move(entry);
+  auto entry = std::make_shared<BacktraceDamage>(ino);
+  entry->path = path;
+  if (log_to_file) {
+    fout << *entry << std::endl;
+  }
+
+  if (!over_sized) {
+    if (auto [it, inserted] = remotes.try_emplace(ino); inserted) {
+      it->second = entry;
+      by_id[entry->id] = std::move(entry);
+    }
+  }
+
+  return false;
+}
+
+bool DamageTable::notify_remote_link_damaged(inodeno_t ino,
+                                             const std::string &path,
+                                             const std::string &head_path) {
+  bool over_sized = oversized();
+  if (!log_to_file && over_sized) {
+    return true;
+  }
+
+  auto entry = std::make_shared<RemoteLinkDamage>(ino, head_path);
+  entry->path = path;
+  if (log_to_file) {
+    fout << *entry << std::endl;
+  }
+
+  if (!over_sized) {
+    auto& df_remote_links = remote_links[ino];
+    if (auto [it, inserted] = df_remote_links.try_emplace(path); inserted) {
+      it->second = entry;
+      by_id[entry->id] = std::move(entry);
+    }
   }
 
   return false;
@@ -263,6 +338,10 @@ bool DamageTable::is_remote_damaged(
   return remotes.count(ino) > 0;
 }
 
+bool DamageTable::is_remote_link_damaged(const inodeno_t ino) const {
+  return remote_links.count(ino) > 0;
+}
+
 void DamageTable::dump(Formatter *f) const
 {
   f->open_array_section("damage_table");
@@ -293,6 +372,19 @@ void DamageTable::erase(damage_entry_id_t damage_id)
   } else if (type == DAMAGE_ENTRY_BACKTRACE) {
     auto backtrace_entry = std::static_pointer_cast<BacktraceDamage>(entry);
     remotes.erase(backtrace_entry->ino);
+  } else if (type == DAMAGE_ENTRY_REMOTE_LINK) {
+    auto remote_link_entry = std::static_pointer_cast<RemoteLinkDamage>(entry);
+    auto df_remote_link_it = remote_links.find(remote_link_entry->ino);
+    if (df_remote_link_it != remote_links.end()) {
+      auto damage_it = df_remote_link_it->second.find(entry->path);
+      if (damage_it != df_remote_link_it->second.end()) {
+        df_remote_link_it->second.erase(entry->path);
+      }
+      if(df_remote_link_it->second.empty()) {
+        remote_links.erase(df_remote_link_it);
+      }
+    }
+    remote_links.erase(remote_link_entry->ino);
   } else {
     derr << "Invalid type " << type << dendl;
     ceph_abort();
@@ -301,3 +393,52 @@ void DamageTable::erase(damage_entry_id_t damage_id)
   by_id.erase(by_id_entry);
 }
 
+bool DamageTable::open_damage_log_file(std::ofstream &fout,
+                                       const std::filesystem::path &file_path) {
+  namespace fs = std::filesystem;
+
+  // Reset the stream in case it was previously used
+  if (fout.is_open()) {
+    fout.close();
+  }
+  fout.clear(); // clear any error flags
+
+  const fs::path dir = file_path.parent_path();
+
+  // Create parent directories if needed
+  if (!dir.empty()) {
+    std::error_code ec;
+
+    if (!fs::exists(dir, ec)) {
+      if (ec) {
+        dout(0) << "error checking existence of damage dir: " << dir << " ("
+                << ec.message() << ")" << dendl;
+        return false;
+      }
+
+      if (!fs::create_directories(dir, ec)) {
+        dout(0) << "failed to create directories for damage file: " << dir
+                << " (" << ec.message() << ")" << dendl;
+        return false;
+      }
+    }
+  }
+
+  // Open in append mode so we keep previous log contents
+  fout.open(file_path, std::ios::out | std::ios::app);
+
+  if (!fout.is_open()) {
+    dout(0) << "failed to open damage file: " << file_path << dendl;
+    return false;
+  }
+
+  return true;
+}
+
+void DamageTable::clear() {
+  dirfrags.clear();
+  dentries.clear();
+  remotes.clear();
+  remote_links.clear();
+  by_id.clear();
+}

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -402,6 +402,9 @@ void MDSDaemon::set_up_admin_socket()
 				     asok_hook,
 				     "Remove a damage table entry");
   ceph_assert(r == 0);
+  r = admin_socket->register_command("damage clear", asok_hook,
+                                     "clear the damage list");
+  ceph_assert(r == 0);
   r = admin_socket->register_command("osdmap barrier name=target_epoch,type=CephInt",
 				     asok_hook,
 				     "Wait until the MDS has this OSD map epoch");

--- a/src/mds/ScrubHeader.h
+++ b/src/mds/ScrubHeader.h
@@ -64,6 +64,18 @@ public:
   }
   unsigned get_num_pending() const { return num_pending; }
 
+  void inc_scrubbed_inode_count() { ++scrubbed_inode_count; }
+
+  uint64_t get_scrubbed_inode_count() const { return scrubbed_inode_count; }
+
+  void inc_scrubbed_remote_link_count(uint64_t val = 1) {
+    scrubbed_remote_link_count += val;
+  }
+
+  uint64_t get_scrubbed_remote_link_count() const {
+    return scrubbed_remote_link_count;
+  }
+
 protected:
   const std::string tag;
   bool is_tag_internal;
@@ -76,6 +88,8 @@ protected:
   bool repaired = false;  // May be set during scrub if repairs happened
   unsigned epoch_last_forwarded = 0;
   unsigned num_pending = 0;
+  uint64_t scrubbed_inode_count = 0;
+  uint64_t scrubbed_remote_link_count = 0;
 };
 
 typedef std::shared_ptr<ScrubHeader> ScrubHeaderRef;


### PR DESCRIPTION
1. remote link damage identification with reverse parent scrubbing
   - remote link identification becomes tricky if inode is cached.
   - Try to open the link normally, if issue while opening mark as damaged
   - If openned successfully, it can be possible there is damage but inode is cached that's why it is succssful while opening. In that case take that openned inode, and scrub ancestors recursively. If any of the ancestor is damaged it remote link is marked as damaged.
   - while scrubbing some flag is maintained in the inode, e.g. whether scrub is backward or forward or both
   - his backward scrubbing will only work in read-only scrub that means without repair flag and mds_scrub_hard_link this ceph flag is turned on.
   - A new type of damage introduced, using which multiple links point to same inode can be identified, which was not possible previously.
2. mds_damage_log_to_file and mds_damage_log_file is used to print out damages in a file persistently as it's not safe to keep it in memory
3. missing dirfrag can make scrub recurring, so a flag `from_scrub` is used to identify when dirfrag fetch is from scrub function.






<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
