### PR TITLE
mds: scrub fix

### DIFF
--- a/qa/suites/fs/functional/tasks/scrub.yaml
+++ b/qa/suites/fs/functional/tasks/scrub.yaml
@@ -8,6 +8,7 @@ overrides:
       - bad backtrace on inode
       - overall HEALTH_
       - \(MDS_TRIM\)
+      - object missing on disk
     conf:
       mds:
         mds log max segments: 1

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -364,6 +364,149 @@ class NonDefaultLayout(Workload):
 class TestDataScan(CephFSTestCase):
     MDSS_REQUIRED = 2
 
+    def _write_tool_file(self, path, content):
+        self.fs.tool_remote.sh(script=[
+            'python3', '-c',
+            ("from pathlib import Path; "
+             "Path({path!r}).write_text({content!r}, encoding='utf-8')".format(path=path, content=content))
+        ])
+
+    def _read_pool_xattr(self, pool, oid, xattr):
+        return self.fs.rados(['getxattr', oid, xattr, '-'], pool=pool, stdout=BytesIO()).stdout.getvalue()
+
+    def _clear_scan_xattrs(self, oid, pools=None):
+        if pools is None:
+            pools = self.fs.get_data_pool_names()
+
+        for pool in pools:
+            for xattr in ['scan_ceiling', 'scan_max_size', 'scan_max_mtime', 'scan_pool_id']:
+                try:
+                    self.fs.rados(['rmxattr', oid, xattr], pool=pool)
+                except CommandFailedError:
+                    pass
+
+    def _create_targeted_scan_fixture(self, file_count=10, extent_count=20, object_size=4194304):
+        default_pool_name = self.fs.get_data_pool_name()
+        extra_pool_name = self._prepare_extra_data_pool(set_root_layout=False)
+
+        layout_default = {
+            'stripe_unit': object_size,
+            'stripe_count': 1,
+            'object_size': object_size,
+            'pool': default_pool_name,
+        }
+        layout_extra = {
+            'stripe_unit': object_size,
+            'stripe_count': 1,
+            'object_size': object_size,
+            'pool': extra_pool_name,
+        }
+
+        self.mount_a.run_shell(['mkdir', 'targeted_default'])
+        self.mount_a.run_shell(['mkdir', 'targeted_extra'])
+        self.fs.set_dir_layout(self.mount_a, 'targeted_default', layout_default)
+        self.fs.set_dir_layout(self.mount_a, 'targeted_extra', layout_extra)
+
+        target_size = object_size * extent_count
+        files = []
+        for i in range(file_count):
+            if i % 2 == 0:
+                path = 'targeted_default/file_{0}'.format(i)
+                pool = default_pool_name
+                is_extra_pool = False
+            else:
+                path = 'targeted_extra/file_{0}'.format(i)
+                pool = extra_pool_name
+                is_extra_pool = True
+
+            self.mount_a.write_test_pattern(path, target_size)
+            ino = self.mount_a.path_to_ino(path)
+            files.append({'path': path, 'ino': ino, 'pool': pool, 'is_extra_pool': is_extra_pool})
+
+        self.fs.mds_asok(['flush', 'journal'])
+        self.mount_a.umount_wait()
+        self.fs.fail()
+
+        for i, f in enumerate(files):
+            if i in (0, 5):
+                missing_extents = tuple(range(0, extent_count))
+            elif i in (1, 6, 9):
+                missing_extents = tuple(range(4, 8))
+            elif i in (2, 4, 7):
+                missing_extents = tuple(range(0, 4))
+            else:
+                missing_extents = (3, 7, 11, 17)
+
+            f['missing_extents'] = set(missing_extents)
+            for extent_id in missing_extents:
+                oid = '{0:x}.{1:08x}'.format(f['ino'], extent_id)
+                try:
+                    self.fs.rados(['rm', oid], pool=f['pool'])
+                except CommandFailedError:
+                    pass
+
+                if f['is_extra_pool'] and extent_id == 0:
+                    try:
+                        self.fs.rados(['rm', oid], pool=default_pool_name)
+                    except CommandFailedError:
+                        pass
+
+        return {
+            'files': files,
+            'default_pool': default_pool_name,
+            'extra_pool': extra_pool_name,
+            'extent_limit': extent_count,
+            'object_size': object_size,
+        }
+
+    def _decode_u64_xattr(self, raw):
+        if len(raw) == 0:
+            return 0
+        self.assertEqual(len(raw), 8)
+        return int.from_bytes(raw, byteorder='little', signed=False)
+
+    def _decode_obj_ceiling_xattr(self, raw):
+        if len(raw) == 0:
+            return (0, 0)
+
+        if len(raw) >= 6:
+            payload_len = int.from_bytes(raw[2:6], byteorder='little', signed=False)
+            payload = raw[6:6 + payload_len]
+            if len(payload) == 0:
+                return (0, 0)
+            if len(payload) >= 16:
+                obj_id = int.from_bytes(payload[0:8], byteorder='little', signed=False)
+                obj_size = int.from_bytes(payload[8:16], byteorder='little', signed=False)
+                return (obj_id, obj_size)
+
+        self.assertGreaterEqual(len(raw), 16)
+        obj_id = int.from_bytes(raw[0:8], byteorder='little', signed=False)
+        obj_size = int.from_bytes(raw[8:16], byteorder='little', signed=False)
+        return (obj_id, obj_size)
+
+    def _expected_inode_scan_result(self, file_info, extent_limit, extent_period, object_size):
+        ceiling = None
+        for window_start in range(0, extent_limit, extent_period):
+            window_end = min(window_start + extent_period, extent_limit)
+            present = [extent_id for extent_id in range(window_start, window_end)
+                       if extent_id not in file_info['missing_extents']]
+            if not present:
+                break
+            ceiling = max(present)
+
+        if ceiling is None:
+            return {
+                'scan_max_size': 0,
+                'scan_ceiling_id': 0,
+                'scan_ceiling_size': 0,
+            }
+
+        return {
+            'scan_max_size': object_size,
+            'scan_ceiling_id': ceiling,
+            'scan_ceiling_size': object_size,
+        }
+
     def is_marked_damaged(self, rank):
         mds_map = self.fs.get_mds_map()
         return rank in mds_map['damaged']
@@ -455,6 +598,313 @@ class TestDataScan(CephFSTestCase):
 
     def test_rebuild_simple(self):
         self._rebuild_metadata(SimpleWorkload(self.fs, self.mount_a))
+
+    def test_scan_extents_targeted_arg_validation(self):
+        with self.assertRaises(CommandFailedError):
+            self.fs.data_scan(['scan_extents', '--extent-period', '0', '--inode-file', '/tmp/nope'])
+
+        with self.assertRaises(CommandFailedError):
+            self.fs.data_scan(['scan_extents', '--extent-limit', '0', '--inode-file', '/tmp/nope'])
+
+        with self.assertRaises(CommandFailedError):
+            self.fs.data_scan(['scan_extents', '--extent-period', 'abc', '--inode-file', '/tmp/nope'])
+
+        with self.assertRaises(CommandFailedError):
+            self.fs.data_scan(['scan_extents', '--extent-limit', 'abc', '--inode-file', '/tmp/nope'])
+
+        with self.assertRaises(CommandFailedError):
+            self.fs.data_scan(['scan_extents', '--extent-period', '1'])
+
+        with self.assertRaises(CommandFailedError):
+            self.fs.data_scan(['scan_extents', '--force-create-head-inode'])
+
+        with self.assertRaises(CommandFailedError):
+            self.fs.data_scan(['scan_inodes', '--force-create-head-inode'])
+
+    def test_scan_extents_inode_file_matches_manual_expectation(self):
+        fixture = self._create_targeted_scan_fixture(file_count=10, extent_count=20)
+        try:
+            inode_file = '/tmp/dscan_0005_inode_period_default.txt'
+            inode_lines = '\n'.join([str(f['ino']) for f in fixture['files']]) + '\n'
+            self._write_tool_file(inode_file, inode_lines)
+
+            self.fs.data_scan([
+                'scan_extents', '--force-pool', '--force-create-head-inode', '--inode-file', inode_file,
+                '--extent-period', '4', '--extent-limit', str(fixture['extent_limit']),
+                fixture['default_pool'], fixture['extra_pool']
+            ])
+
+            for f in fixture['files']:
+
+                oid = '{0:x}.00000000'.format(f['ino'])
+                expected = self._expected_inode_scan_result(f, fixture['extent_limit'], 4, fixture['object_size'])
+
+                scan_max_size = self._decode_u64_xattr(self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_size'))
+                self.assertEqual(
+                    expected['scan_max_size'],
+                    scan_max_size,
+                    'path={0} ino=0x{1:x} expected scan_max_size={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_max_size'], scan_max_size))
+
+                scan_ceiling_id, scan_ceiling_size = self._decode_obj_ceiling_xattr(
+                    self._read_pool_xattr(fixture['default_pool'], oid, 'scan_ceiling'))
+                self.assertEqual(
+                    expected['scan_ceiling_id'],
+                    scan_ceiling_id,
+                    'path={0} ino=0x{1:x} expected scan_ceiling_id={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_ceiling_id'], scan_ceiling_id))
+                self.assertEqual(
+                    expected['scan_ceiling_size'],
+                    scan_ceiling_size,
+                    'path={0} ino=0x{1:x} expected scan_ceiling_size={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_ceiling_size'], scan_ceiling_size))
+        finally:
+            self.fs.set_joinable()
+            self.fs.wait_for_daemons()
+            self.mount_a.mount_wait()
+
+    def test_scan_extents_damage_file_matches_manual_expectation(self):
+        fixture = self._create_targeted_scan_fixture(file_count=10, extent_count=20)
+        try:
+            damage_file = '/tmp/dscan_0005_damage_period_default.jsonl'
+            damage_lines = []
+            for f in fixture['files']:
+                damage_lines.append(json.dumps({'damage_type': 'backtrace', 'ino': f['ino']}))
+            self._write_tool_file(damage_file, '\n'.join(damage_lines) + '\n')
+
+
+            self.fs.data_scan([
+                'scan_extents', '--force-pool', '--force-create-head-inode', '--damage-file', damage_file,
+                '--extent-period', '4', '--extent-limit', str(fixture['extent_limit']),
+                fixture['default_pool'], fixture['extra_pool']
+            ])
+
+            for f in fixture['files']:
+
+                oid = '{0:x}.00000000'.format(f['ino'])
+                expected = self._expected_inode_scan_result(f, fixture['extent_limit'], 4, fixture['object_size'])
+
+                scan_max_size = self._decode_u64_xattr(self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_size'))
+                self.assertEqual(
+                    expected['scan_max_size'],
+                    scan_max_size,
+                    'path={0} ino=0x{1:x} expected scan_max_size={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_max_size'], scan_max_size))
+
+                scan_ceiling_id, scan_ceiling_size = self._decode_obj_ceiling_xattr(
+                    self._read_pool_xattr(fixture['default_pool'], oid, 'scan_ceiling'))
+                self.assertEqual(
+                    expected['scan_ceiling_id'],
+                    scan_ceiling_id,
+                    'path={0} ino=0x{1:x} expected scan_ceiling_id={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_ceiling_id'], scan_ceiling_id))
+                self.assertEqual(
+                    expected['scan_ceiling_size'],
+                    scan_ceiling_size,
+                    'path={0} ino=0x{1:x} expected scan_ceiling_size={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_ceiling_size'], scan_ceiling_size))
+        finally:
+            self.fs.set_joinable()
+            self.fs.wait_for_daemons()
+            self.mount_a.mount_wait()
+
+    def test_scan_extents_inode_file_no_force_skips_empty_flush(self):
+        fixture = self._create_targeted_scan_fixture(file_count=10, extent_count=20)
+        try:
+            inode_file = '/tmp/dscan_0006_inode_no_force.txt'
+            inode_lines = '\n'.join([str(f['ino']) for f in fixture['files']]) + '\n'
+            self._write_tool_file(inode_file, inode_lines)
+
+            self.fs.data_scan([
+                'scan_extents', '--force-pool', '--inode-file', inode_file,
+                '--extent-period', '4', '--extent-limit', str(fixture['extent_limit']),
+                fixture['default_pool'], fixture['extra_pool']
+            ])
+
+            for f in fixture['files']:
+                oid = '{0:x}.00000000'.format(f['ino'])
+                expected = self._expected_inode_scan_result(f, fixture['extent_limit'], 4, fixture['object_size'])
+
+                if expected['scan_max_size'] == 0 and expected['scan_ceiling_id'] == 0:
+                    with self.assertRaises(CommandFailedError):
+                        self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_size')
+                    with self.assertRaises(CommandFailedError):
+                        self._read_pool_xattr(fixture['default_pool'], oid, 'scan_ceiling')
+                    continue
+
+                scan_max_size = self._decode_u64_xattr(
+                    self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_size'))
+                self.assertEqual(
+                    expected['scan_max_size'],
+                    scan_max_size,
+                    'path={0} ino=0x{1:x} expected scan_max_size={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_max_size'], scan_max_size))
+
+                scan_ceiling_id, scan_ceiling_size = self._decode_obj_ceiling_xattr(
+                    self._read_pool_xattr(fixture['default_pool'], oid, 'scan_ceiling'))
+                self.assertEqual(
+                    expected['scan_ceiling_id'],
+                    scan_ceiling_id,
+                    'path={0} ino=0x{1:x} expected scan_ceiling_id={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_ceiling_id'], scan_ceiling_id))
+                self.assertEqual(
+                    expected['scan_ceiling_size'],
+                    scan_ceiling_size,
+                    'path={0} ino=0x{1:x} expected scan_ceiling_size={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_ceiling_size'], scan_ceiling_size))
+        finally:
+            self.fs.set_joinable()
+            self.fs.wait_for_daemons()
+            self.mount_a.mount_wait()
+
+    def test_scan_extents_damage_file_no_force_skips_empty_flush(self):
+        fixture = self._create_targeted_scan_fixture(file_count=10, extent_count=20)
+        try:
+            damage_file = '/tmp/dscan_0006_damage_no_force.jsonl'
+            damage_lines = []
+            for f in fixture['files']:
+                damage_lines.append(json.dumps({'damage_type': 'backtrace', 'ino': f['ino']}))
+            self._write_tool_file(damage_file, '\n'.join(damage_lines) + '\n')
+
+            self.fs.data_scan([
+                'scan_extents', '--force-pool', '--damage-file', damage_file,
+                '--extent-period', '4', '--extent-limit', str(fixture['extent_limit']),
+                fixture['default_pool'], fixture['extra_pool']
+            ])
+
+            for f in fixture['files']:
+                oid = '{0:x}.00000000'.format(f['ino'])
+                expected = self._expected_inode_scan_result(f, fixture['extent_limit'], 4, fixture['object_size'])
+
+                if expected['scan_max_size'] == 0 and expected['scan_ceiling_id'] == 0:
+                    with self.assertRaises(CommandFailedError):
+                        self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_size')
+                    with self.assertRaises(CommandFailedError):
+                        self._read_pool_xattr(fixture['default_pool'], oid, 'scan_ceiling')
+                    continue
+
+                scan_max_size = self._decode_u64_xattr(
+                    self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_size'))
+                self.assertEqual(
+                    expected['scan_max_size'],
+                    scan_max_size,
+                    'path={0} ino=0x{1:x} expected scan_max_size={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_max_size'], scan_max_size))
+
+                scan_ceiling_id, scan_ceiling_size = self._decode_obj_ceiling_xattr(
+                    self._read_pool_xattr(fixture['default_pool'], oid, 'scan_ceiling'))
+                self.assertEqual(
+                    expected['scan_ceiling_id'],
+                    scan_ceiling_id,
+                    'path={0} ino=0x{1:x} expected scan_ceiling_id={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_ceiling_id'], scan_ceiling_id))
+                self.assertEqual(
+                    expected['scan_ceiling_size'],
+                    scan_ceiling_size,
+                    'path={0} ino=0x{1:x} expected scan_ceiling_size={2} actual={3}'.format(
+                        f['path'], f['ino'], expected['scan_ceiling_size'], scan_ceiling_size))
+        finally:
+            self.fs.set_joinable()
+            self.fs.wait_for_daemons()
+            self.mount_a.mount_wait()
+
+    def test_scan_extents_damage_file_parity_with_inode_file(self):
+        fixture = self._create_targeted_scan_fixture(file_count=10, extent_count=20)
+        try:
+            inode_file = '/tmp/dscan_0005_inode_parity.txt'
+            damage_file = '/tmp/dscan_0005_damage_parity.jsonl'
+            inode_lines = []
+            damage_lines = []
+            for f in fixture['files']:
+                inode_lines.append(str(f['ino']))
+                damage_lines.append(json.dumps({'damage_type': 'backtrace', 'ino': f['ino']}))
+
+            self._write_tool_file(inode_file, '\n'.join(inode_lines) + '\n')
+            self._write_tool_file(damage_file, '\n'.join(damage_lines) + '\n')
+
+            self.fs.data_scan([
+                'scan_extents', '--force-pool', '--force-create-head-inode', '--inode-file', inode_file,
+                '--extent-period', '4', '--extent-limit', str(fixture['extent_limit']),
+                fixture['default_pool'], fixture['extra_pool']
+            ])
+
+            inode_scan_result = {}
+            for f in fixture['files']:
+
+                oid = '{0:x}.00000000'.format(f['ino'])
+                try:
+                    baseline_scan_pool_id = self._read_pool_xattr(fixture['default_pool'], oid, 'scan_pool_id')
+                except CommandFailedError:
+                    baseline_scan_pool_id = None
+
+                inode_scan_result[f['ino']] = {
+                    'scan_max_size': self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_size'),
+                    'scan_max_mtime': self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_mtime'),
+                    'scan_ceiling': self._read_pool_xattr(fixture['default_pool'], oid, 'scan_ceiling'),
+                    'scan_pool_id': baseline_scan_pool_id,
+                }
+
+            for f in fixture['files']:
+                oid = '{0:x}.00000000'.format(f['ino'])
+                self._clear_scan_xattrs(oid, pools=[fixture['default_pool']])
+                if 0 in f['missing_extents']:
+                    for pool in [fixture['default_pool'], fixture['extra_pool']]:
+                        try:
+                            self.fs.rados(['rm', oid], pool=pool)
+                        except CommandFailedError:
+                            pass
+
+            self.fs.data_scan([
+                'scan_extents', '--force-pool', '--force-create-head-inode', '--damage-file', damage_file,
+                '--extent-period', '4', '--extent-limit', str(fixture['extent_limit']),
+                fixture['default_pool'], fixture['extra_pool']
+            ])
+
+            for f in fixture['files']:
+
+                oid = '{0:x}.00000000'.format(f['ino'])
+                damage_max_size_raw = self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_size')
+                self.assertEqual(
+                    inode_scan_result[f['ino']]['scan_max_size'],
+                    damage_max_size_raw,
+                    'path={0} ino=0x{1:x} expected scan_max_size={2} actual={3}'.format(
+                        f['path'],
+                        f['ino'],
+                        self._decode_u64_xattr(inode_scan_result[f['ino']]['scan_max_size']),
+                        self._decode_u64_xattr(damage_max_size_raw),
+                    ),
+                )
+                baseline_mtime = self._decode_u64_xattr(inode_scan_result[f['ino']]['scan_max_mtime'])
+                damage_mtime = self._decode_u64_xattr(self._read_pool_xattr(fixture['default_pool'], oid, 'scan_max_mtime'))
+                self.assertGreaterEqual(
+                    damage_mtime,
+                    baseline_mtime,
+                    'path={0} ino=0x{1:x} expected scan_max_mtime >= {2} actual={3}'.format(
+                        f['path'], f['ino'], baseline_mtime, damage_mtime),
+                )
+                self.assertEqual(
+                    inode_scan_result[f['ino']]['scan_ceiling'],
+                    self._read_pool_xattr(fixture['default_pool'], oid, 'scan_ceiling'),
+                    'path={0} ino=0x{1:x} scan_ceiling mismatch'.format(f['path'], f['ino']),
+                )
+
+            for f in fixture['files']:
+
+                oid = '{0:x}.00000000'.format(f['ino'])
+                baseline_scan_pool_id = inode_scan_result[f['ino']]['scan_pool_id']
+                if baseline_scan_pool_id is None:
+                    with self.assertRaises(CommandFailedError):
+                        self._read_pool_xattr(fixture['default_pool'], oid, 'scan_pool_id')
+                else:
+                    self.assertEqual(
+                        baseline_scan_pool_id,
+                        self._read_pool_xattr(fixture['default_pool'], oid, 'scan_pool_id'),
+                        'path={0} ino=0x{1:x} scan_pool_id mismatch'.format(f['path'], f['ino']),
+                    )
+        finally:
+            self.fs.set_joinable()
+            self.fs.wait_for_daemons()
+            self.mount_a.mount_wait()
 
     def test_rebuild_symlink(self):
         self._rebuild_metadata(SymlinkWorkload(self.fs, self.mount_a))

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -1531,7 +1531,7 @@ class TestDataScan(CephFSTestCase):
                 self.fs.data_scan(["scan_frags", "--force-corrupt"])
 
             log.info("running data_scan scan_links")
-            self.fs.data_scan(["scan_links"])
+            self.fs.data_scan(["scan_links", "--thread-count", "4"])
 
             self._restart_mds_after_data_scan()
 

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -9,6 +9,7 @@ import os
 import time
 import traceback
 import stat
+import rados
 
 from io import BytesIO, StringIO
 from collections import namedtuple, defaultdict
@@ -365,11 +366,36 @@ class TestDataScan(CephFSTestCase):
     MDSS_REQUIRED = 2
 
     def _write_tool_file(self, path, content):
-        self.fs.tool_remote.sh(script=[
-            'python3', '-c',
-            ("from pathlib import Path; "
-             "Path({path!r}).write_text({content!r}, encoding='utf-8')".format(path=path, content=content))
-        ])
+        self.fs.tool_remote.run(
+            args=[
+                "python3",
+                "-c",
+                "import sys; from pathlib import Path; Path(sys.argv[1]).write_bytes(sys.stdin.buffer.read())",
+                path,
+            ],
+            stdin=BytesIO(content.encode("utf-8")),
+        )
+
+    @staticmethod
+    def json_validator(json_out, rc, element, expected_value):
+        if rc != 0:
+            return False, "asok command returned error {rc}".format(rc=rc)
+        element_value = json_out.get(element)
+        if element_value != expected_value:
+            return False, "unexpectedly got {jv} instead of {ev}!".format(
+                jv=element_value, ev=expected_value)
+        return True, "Succeeded"
+
+    def tell_command(self, mds_rank, command, validator=None):
+        command_list = command.split()
+        jout = self.fs.rank_tell(command_list, rank=mds_rank)
+        if validator:
+            success, errstring = validator(jout, 0)
+            if not success:
+                self.fail("command '{cmd}' failed validation: {err}".format(
+                    cmd=command, err=errstring))
+        return jout
+
 
     def _read_pool_xattr(self, pool, oid, xattr):
         return self.fs.rados(['getxattr', oid, xattr, '-'], pool=pool, stdout=BytesIO()).stdout.getvalue()
@@ -1220,6 +1246,324 @@ class TestDataScan(CephFSTestCase):
         self.assertNotEqual(out_json, None)
         self.assertEqual(out_json["return_code"], 0)
         self.assertEqual(self.fs.wait_until_scrub_complete(tag=out_json["scrub_tag"]), True)
+
+    def _build_remote_link_entry_path(self, base_dir, level, serial, branch):
+        path_part = ""
+        cur_serial = serial
+        for cur_level in range(level, -1, -1):
+            name = f"e_{cur_level}_{cur_serial}"
+            if path_part:
+                path_part = os.path.join(name, path_part)
+            else:
+                path_part = name
+            cur_serial //= branch
+        return os.path.join(base_dir, path_part)
+
+    def _create_remote_link_topology(self, base_dir, levels, branch):
+        log.info("creating remote_link topology: base_dir=%s levels=%s branch=%s", base_dir, levels, branch)
+        level0_path = self._build_remote_link_entry_path(base_dir, 0, 0, branch)
+        self.mount_a.run_shell(["mkdir", "-p", level0_path])
+
+        for level in range(1, levels):
+            count = branch ** level
+            for serial in range(count):
+                entry_path = self._build_remote_link_entry_path(base_dir, level, serial, branch)
+                self.mount_a.run_shell(["mkdir", entry_path])
+
+        part_span = branch ** (levels - 1)
+        for x in range(part_span):
+            serial_last = (branch - 1) * part_span + x
+            file_path = self._build_remote_link_entry_path(base_dir, levels, serial_last, branch)
+            self.mount_a.run_shell(["touch", file_path])
+            prev_path = file_path
+            for t in range(branch - 2, -1, -1):
+                serial = t * part_span + x
+                link_path = self._build_remote_link_entry_path(base_dir, levels, serial, branch)
+                self.mount_a.run_shell(["ln", prev_path, link_path])
+                prev_path = link_path
+        return part_span
+
+    def _inject_remote_link_damage(self, test_dir_path, levels, branch, meta_ioctx, data_ioctx):
+        log.info("injecting remote_link damage: test_dir=%s levels=%s branch=%s", test_dir_path, levels, branch)
+        level1_serial = branch - 1
+
+        for i in range(branch):
+            level2_serial = level1_serial * branch + i
+
+            for level in range(2, levels + 1):
+                if level < levels and level % 2 != 0:
+                    continue
+                if level == levels and i != (branch - 1):
+                    continue
+
+                base = branch ** (level - 2)
+                for x in range(base):
+                    serial = level2_serial * base + x
+                    entry_path = self._build_remote_link_entry_path(
+                        test_dir_path, level, serial, branch
+                    )
+                    ino = self.mount_a.path_to_ino(entry_path)
+                    ioctx = data_ioctx if level == levels else meta_ioctx
+                    try:
+                        ioctx.remove_object(f"{ino:x}.00000000")
+                    except rados.ObjectNotFound:
+                        pass
+
+    def _collect_remote_link_damage(self, mds_rank, test_dir_path, levels, branch, part_span):
+        log.info("collecting remote_link damage: rank=%s test_dir=%s levels=%s branch=%s", mds_rank, test_dir_path, levels, branch)
+        success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+        scrub_json = self.tell_command(
+            mds_rank,
+            "scrub start / recursive force",
+            success_validator)
+        self.assertEqual(self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"], sleep=5), True)
+
+        damage_json = self.tell_command(mds_rank, "damage ls")
+        remote_link_paths = set(
+            entry["path"] for entry in damage_json if entry.get("damage_type") == "remote_link"
+        )
+
+        missing_links = []
+        hard_link_serial_range = part_span * (branch - 1)
+        for serial in range(hard_link_serial_range):
+            link_path = "/" + self._build_remote_link_entry_path(test_dir_path, levels, serial, branch)
+            if link_path not in remote_link_paths:
+                missing_links.append(link_path)
+
+        if missing_links:
+            self.fail(
+                "missing remote_link damage entries: {0}".format(
+                    ", ".join(missing_links)
+                )
+            )
+
+    def _remove_openfiles_objects(self, meta_ioctx):
+        log.info("removing openfiles objects")
+        x = 0
+        while True:
+            obj_name = f"mds0_openfiles.{x}"
+            try:
+                meta_ioctx.stat(obj_name)
+            except rados.ObjectNotFound:
+                break
+            meta_ioctx.remove_object(obj_name)
+            x += 1
+
+    def _failover_and_cleanup_for_data_scan(self, meta_ioctx, flush_journal=False, cleanup=True):
+        log.info("failover and cleanup: flush_journal=%s cleanup=%s", flush_journal, cleanup)
+        if flush_journal:
+            self.fs.mds_asok(["flush", "journal"])
+        self.fs.fail()
+        if cleanup:
+            self._remove_openfiles_objects(meta_ioctx)
+            self.fs.journal_tool(["journal", "reset"], 0)
+
+    def _restart_mds_after_data_scan(self):
+        log.info("restarting mds after data scan")
+        self.fs.mds_fail_restart()
+        self.fs.set_down(False)
+        self.fs.set_joinable(True)
+        self.fs.wait_for_daemons()
+        status = self.fs.mds_asok(["status"])
+        self.assertEqual("up:active", str(status["state"]))
+        self.mount_a._run_umount_lf()
+        self.mount_a.mount_wait()
+
+    def _load_damage_log_to_tool_remote(self, damage_log_path):
+        log.info("loading damage entries to tool remote path %s", damage_log_path)
+        mds_rank = self.fs.get_rank()["rank"]
+        damage_json = self.tell_command(mds_rank, "damage ls")
+        self.assertTrue(damage_json, "damage ls returned no entries")
+        damage_log = "\n".join(
+            json.dumps(entry, separators=(",", ":")) for entry in damage_json) + "\n"
+        self._write_tool_file(damage_log_path, damage_log)
+
+    def _verify_no_remote_link_damage(self, mds_rank, test_dir_path):
+        log.info("verifying no remote_link damage remains: rank=%s test_dir=%s", mds_rank, test_dir_path)
+        success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+        scrub_json = self.tell_command(
+            mds_rank,
+            "scrub start / recursive force",
+            success_validator)
+        self.assertEqual(self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"], sleep=5), True)
+
+        damage_json = self.tell_command(mds_rank, "damage ls")
+        for entry in damage_json:
+            if entry.get("damage_type") == "remote_link":
+                self.fail(
+                    "unexpected remote_link damage after data-scan repair: {0}".format(
+                        json.dumps(entry, sort_keys=True)
+                    )
+                )
+
+    def _verify_nlink_counts(self, test_dir_path):
+        log.info("verifying nlink counts from path %s", test_dir_path)
+        out = self.mount_a.run_shell(
+            ["find", test_dir_path, "-printf", "%i %y %n %p\n"],
+            stdout=StringIO()).stdout.getvalue()
+
+        file_inode_map = {}
+        file_nlink_map = {}
+        dir_nlink_map = {}
+        dir_paths = set()
+        dir_parent_counts = {}
+
+        for line in out.splitlines():
+            if not line:
+                continue
+            parts = line.split(" ", 3)
+            if len(parts) < 4:
+                continue
+            inode, ftype, nlink, path_str = parts
+            if ftype == "f":
+                file_inode_map.setdefault(inode, set()).add(os.path.basename(path_str))
+                file_nlink_map[inode] = nlink
+            elif ftype == "d":
+                dir_paths.add(path_str)
+                dir_nlink_map[path_str] = nlink
+
+        for dir_path in dir_paths:
+            parent = os.path.dirname(dir_path)
+            if parent in dir_paths:
+                dir_parent_counts[parent] = dir_parent_counts.get(parent, 0) + 1
+
+        file_mismatches = []
+        for inode, names in file_inode_map.items():
+            actual = int(file_nlink_map.get(inode))
+            expected = len(names)
+            if actual != expected:
+                file_mismatches.append((inode, expected, actual))
+        if file_mismatches:
+            details = ", ".join(
+                "{0}: expected {1}, got {2}".format(i, e, a)
+                for i, e, a in file_mismatches)
+            self.fail("nlink mismatch for files: {0}".format(details))
+
+        dir_mismatches = []
+        for dir_path in dir_paths:
+            expected_subdirs = dir_parent_counts.get(dir_path, 0)
+            expected_nlink = 2 + expected_subdirs
+            actual = dir_nlink_map.get(dir_path)
+            if int(actual) != expected_nlink:
+                dir_mismatches.append((dir_path, expected_nlink, actual))
+        if dir_mismatches:
+            details = ", ".join(
+                "{0}: expected {1}, got {2}".format(path, exp, act)
+                for path, exp, act in dir_mismatches)
+            self.fail("nlink mismatch for directories: {0}".format(details))
+
+    def _run_remote_link_damage_repair_with_offline_data_scan(self, restore_all_ancestors):
+        log.info("running remote_link targeted repair flow: restore_all_ancestors=%s", restore_all_ancestors)
+        test_dir_path = "dscan_remote_link"
+        damage_log_path = "/tmp/damage.log"
+        n = 5
+        b = 10
+
+        self.run_ceph_cmd(
+            "config", "set", "global", "mds_damage_table_max_entries", "1000000"
+        )
+        self.run_ceph_cmd(
+            "config", "set", "global", "mds_force_hard_link_scrubbing", "true"
+        )
+        self.run_ceph_cmd(
+            "config", "set", "global", "mds_damage_log_file", damage_log_path
+        )
+        self.run_ceph_cmd(
+            "config", "set", "global", "mds_damage_log_to_file", "true"
+        )
+
+        for daemon in self.fs.mds_daemons.values():
+            daemon.remote.run(args=["sudo", "rm", "-f", damage_log_path])
+
+        self.mount_a.run_shell(["rm", "-rf", test_dir_path])
+        self.mount_a.run_shell(["mkdir", test_dir_path])
+
+        part_span = self._create_remote_link_topology(test_dir_path, n, b)
+        self.fs.mds_asok(["flush", "journal"])
+
+        meta_pool = self.fs.get_metadata_pool_name()
+        data_pool = self.fs.get_data_pool_name()
+        conf = self.mount_a.config_path
+        keyring = self.mount_a.get_keyring_path()
+
+        cluster = rados.Rados(
+            conffile=conf,
+            name="client.admin",
+            conf={"keyring": keyring})
+        cluster.connect()
+        meta_ioctx = cluster.open_ioctx(meta_pool)
+        data_ioctx = cluster.open_ioctx(data_pool)
+
+        try:
+            mds_rank = self.fs.get_rank()["rank"]
+            self._inject_remote_link_damage(test_dir_path, n, b, meta_ioctx, data_ioctx)
+            self._collect_remote_link_damage(mds_rank, test_dir_path, n, b, part_span)
+
+            self._load_damage_log_to_tool_remote(damage_log_path)
+
+            self._failover_and_cleanup_for_data_scan(meta_ioctx, flush_journal=False, cleanup=True)
+            log.info("running data_scan scan_extents for remote_link damages")
+            self.fs.data_scan([
+                "scan_extents",
+                "--force-create-head-inode",
+                "--damage-file", damage_log_path,
+                "--type", "remote_link",
+                "--extent-period", "1",
+                "--extent-limit", "1",
+            ], worker_count=4)
+
+            scan_inodes_args = [
+                "scan_inodes",
+                "--force-corrupt",
+                "--damage-file", damage_log_path,
+                "--type", "remote_link",
+            ]
+            if restore_all_ancestors:
+                scan_inodes_args.insert(2, "--force-restore-all-ancestors")
+            log.info("running data_scan scan_inodes with args: %s", scan_inodes_args)
+            if restore_all_ancestors:
+                self.fs.data_scan(scan_inodes_args)
+            else:
+                self.fs.data_scan(scan_inodes_args, worker_count=4)
+
+            if not restore_all_ancestors:
+                log.info("running data_scan scan_frags --force-corrupt")
+                self.fs.data_scan(["scan_frags", "--force-corrupt"])
+
+            log.info("running data_scan scan_links")
+            self.fs.data_scan(["scan_links"])
+
+            self._restart_mds_after_data_scan()
+
+            mds_rank = self.fs.get_rank()["rank"]
+            self.fs.mds_asok(["damage", "clear"])
+            success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+            scrub_json = self.tell_command(
+                mds_rank,
+                "scrub start / recursive repair force",
+                success_validator)
+            self.assertEqual(self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"], sleep=5), True)
+
+            self.fs.mds_asok(["damage", "clear"])
+
+            self._verify_no_remote_link_damage(mds_rank, test_dir_path)
+            self._verify_nlink_counts(".")
+
+            self.mount_a.run_shell(["rm", "-rf", test_dir_path])
+        finally:
+            meta_ioctx.close()
+            data_ioctx.close()
+            cluster.shutdown()
+
+    def test_remote_link_damage_repair_targeted_no_scan_frags(self):
+        log.info("starting test_remote_link_damage_repair_targeted_no_scan_frags")
+        self._run_remote_link_damage_repair_with_offline_data_scan(
+            restore_all_ancestors=True)
+
+    def test_remote_link_damage_repair_targeted_with_scan_frags(self):
+        log.info("starting test_remote_link_damage_repair_targeted_with_scan_frags")
+        self._run_remote_link_damage_repair_with_offline_data_scan(
+            restore_all_ancestors=False)
 
     def _prepare_extra_data_pool(self, set_root_layout=True):
         extra_data_pool_name = self.fs.get_data_pool_name() + '_extra'

--- a/qa/tasks/cephfs/test_scrub_checks.py
+++ b/qa/tasks/cephfs/test_scrub_checks.py
@@ -5,6 +5,8 @@ import json
 import logging
 import errno
 import time
+import rados
+from io import StringIO, BytesIO
 from teuthology.exceptions import CommandFailedError
 from teuthology.contextutil import safe_while
 import os
@@ -362,6 +364,497 @@ class TestScrubChecks(CephFSTestCase):
         # fragstat should be fixed
         self.mount_a.run_shell(["rmdir", test_dir])
 
+    def test_scrub_remote_link(self):
+        """
+        test scrub remote link
+        """
+        test_dir_path1 = "test_dir1"
+        test_dir_path2 = "test_dir2"
+        self.mount_a.run_shell(["mkdir", test_dir_path1])
+        self.mount_a.run_shell(["mkdir", test_dir_path2])
+
+        self.run_ceph_cmd("config", "set", "global", "mds_log_max_segments", "128")
+        self.fs.mds_asok(['config', 'set', 'mds_log_max_segments', '128'])
+
+        # Filesystem layout: n levels, b-way branching; parent is e_(level-1)_(serial//b)
+        n = 5
+        b = 10
+
+        # Build the absolute path for e_<level>_<serial>
+        def build_entry_path(base_dir, level, serial):
+            path_part = ""
+            cur_serial = serial
+            for cur_level in range(level, -1, -1):
+                name = f"e_{cur_level}_{cur_serial}"
+                if path_part:
+                    path_part = os.path.join(name, path_part)
+                else:
+                    path_part = name
+                cur_serial //= b
+            return os.path.join(base_dir, path_part)
+
+        def create_tree(base_dir):
+            # Create all directory entries for levels 0..n-1
+            level0_path = build_entry_path(base_dir, 0, 0)
+            self.mount_a.run_shell(["mkdir", level0_path])
+
+            for level in range(1, n):
+                count = b ** level
+                for serial in range(count):
+                    entry_path = build_entry_path(base_dir, level, serial)
+                    self.mount_a.run_shell(["mkdir", entry_path])
+
+            # Hardlink strategy: e_n_(i * part_span + x)--> e_n_((i + 1) * part_span + x)
+            # e.g. e_n_0->e_n_10000->e_n_20000->e_n_30000->e_n_40000...e_n_90000
+            # e_n_[90000...99999] are all files and e_n_[0...89999] are all hardlinks
+            part_span = b ** (n - 1)
+
+            for x in range(part_span):
+                print(f"creating link chain-{x}")
+                serial_last = (b - 1) * part_span + x
+                file_path_candidate = build_entry_path(base_dir, n, serial_last)
+                self.mount_a.run_shell(["touch", file_path_candidate])
+                prev_path = file_path_candidate
+                for t in range(b - 2, -1, -1):
+                    serial = t * part_span + x
+                    link_path_candidate = build_entry_path(base_dir, n, serial)
+                    self.mount_a.run_shell(["ln", prev_path, link_path_candidate])
+                    prev_path = link_path_candidate
+            return part_span
+
+        part_span = create_tree(test_dir_path1)
+        # Goal of this creating identical directory like test_dir_path1
+        # is, we will do all the destructive operation on test_dir_path1
+        # and make sure test_dir_path2 is intact
+        create_tree(test_dir_path2)
+
+        self.run_ceph_cmd("config", "set", "global", "mds_damage_table_max_entries", "1000000")
+        self.run_ceph_cmd("config", "set", "global", "mds_force_hard_link_scrubbing", "true")
+
+        # Flush to persist objects before damage injection
+        self.fs.flush()
+
+        meta_pool = self.fs.get_metadata_pool_name()
+        data_pool = self.fs.get_data_pool_name()
+
+        conf = self.mount_a.config_path
+        keyring = self.mount_a.get_keyring_path()
+        cluster = rados.Rados(conffile=conf,
+                              name="client.admin",
+                              conf={"keyring": keyring})
+        cluster.connect()
+        meta_ioctx = cluster.open_ioctx(meta_pool)
+        data_ioctx = cluster.open_ioctx(data_pool)
+        mds_rank = self.fs.get_rank()['rank']
+        self.inject_damage(
+            test_dir_path1, build_entry_path, n, b,
+            meta_ioctx, data_ioctx)
+        remote_link_entries = self.verify_remote_link_damage(
+            mds_rank, test_dir_path1, build_entry_path, n, b, part_span)
+        self.fix_remote_link_damage(
+            remote_link_entries, mds_rank, test_dir_path1, meta_ioctx)
+
+        success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+        scrub_json = self.tell_command(
+            mds_rank, "scrub start / recursive scrub_mdsdir", success_validator)
+        self.assertEqual(
+            self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"], sleep=5), True)
+
+        self.verify_remote_link_existence(mds_rank, test_dir_path1)
+
+
+        self.verify_nlink_counts(test_dir_path1)
+        self.verify_nlink_counts(test_dir_path2)
+
+
+        self.remove_test_dir_and_verify(test_dir_path1, meta_ioctx, data_ioctx)
+        self.remove_test_dir_and_verify(test_dir_path2, meta_ioctx, data_ioctx)
+
+        meta_ioctx.close()
+        data_ioctx.close()
+        cluster.shutdown()
+
+
+    def fix_remote_link_damage(self, remote_link_entries, mds_rank,
+                                test_dir_path, meta_ioctx):
+        self.failover_and_cleanup(meta_ioctx, False, True)
+        self.restart_mds()
+
+        success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+        scrub_json = self.tell_command(
+            mds_rank,
+            "scrub start {0} recursive repair force".format(
+                test_dir_path if test_dir_path.startswith("/") else "/" + test_dir_path),
+            success_validator)
+        self.assertEqual(
+            self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"], sleep=5), True)
+
+        self.failover_and_cleanup(meta_ioctx, True, True)
+        self.restart_mds()
+
+        success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+        scrub_json = self.tell_command(
+            mds_rank,
+            "scrub start {0} recursive force".format(
+                test_dir_path if test_dir_path.startswith("/") else "/" + test_dir_path),
+            success_validator)
+        self.assertEqual(
+            self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"], sleep=5), True)
+        damage_json = self.tell_command(mds_rank, "damage ls")
+
+        remote_link_entries = {
+            entry["path"]: entry for entry in damage_json
+            if entry.get("damage_type") == "remote_link"
+        }
+
+
+        self.failover_and_cleanup(meta_ioctx, True, True)
+        missing_parent_inos = []
+        missing_omap_keys = []
+        bad_root_parents = []
+        missing_parent_dirfrags = []
+        total_links = len(remote_link_entries)
+        for idx, (link_path, entry) in enumerate(remote_link_entries.items(), start=1):
+            if idx % 10 == 0 or idx == total_links:
+                log.info(
+                    "fix_remote_link_damage: remote_link parent check %d/%d",
+                    idx, total_links)
+            parent_ino = entry.get("parent_ino")
+            if parent_ino is None:
+                missing_parent_inos.append(link_path)
+                continue
+            if parent_ino == 0:
+                parent_dir = os.path.dirname(link_path)
+                if parent_dir != "/":
+                    bad_root_parents.append(link_path)
+                continue
+            key = "{0}_head".format(os.path.basename(link_path))
+            dirfrag_obj_name = "{0:x}.00000000".format(parent_ino)
+            try:
+                meta_ioctx.stat(dirfrag_obj_name)
+            except rados.ObjectNotFound:
+                missing_parent_dirfrags.append(link_path)
+                continue
+            with rados.ReadOpCtx() as read_op:
+                it, _ = meta_ioctx.get_omap_vals_by_keys(read_op, (key,), omap_key_type=bytes)
+                meta_ioctx.operate_read_op(read_op, dirfrag_obj_name)
+                omap_vals = list(it)
+            if not omap_vals:
+                missing_omap_keys.append(link_path)
+                continue
+            with rados.WriteOpCtx() as write_op:
+                meta_ioctx.remove_omap_keys(write_op, (key,))
+                meta_ioctx.operate_write_op(write_op, dirfrag_obj_name)
+        if missing_parent_inos:
+            self.fail("missing parent_ino in remote_link damage entries: {0}".format(
+                ", ".join(missing_parent_inos)))
+        if bad_root_parents:
+            self.fail("parent_ino is 0 but parent path is not '/': {0}".format(
+                ", ".join(bad_root_parents)))
+        if missing_parent_dirfrags:
+            self.fail("missing parent dirfrag objects for remote_link entries: {0}".format(
+                ", ".join(missing_parent_dirfrags)))
+        if missing_omap_keys:
+            self.fail("missing _head omap keys for remote_link parents: {0}".format(
+                ", ".join(missing_omap_keys)))
+        self.restart_mds()
+
+        success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+        scrub_json = self.tell_command(
+            mds_rank,
+            "scrub start {0} recursive repair force".format(
+                test_dir_path if test_dir_path.startswith("/") else "/" + test_dir_path),
+            success_validator)
+        self.assertEqual(
+            self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"], sleep=5), True)
+        damage_json = self.tell_command(mds_rank, "damage ls")
+        self.failover_and_cleanup(meta_ioctx, True, True)
+        self.restart_mds()
+
+
+    def failover_and_cleanup(self, meta_ioctx, flush_jounrnal, cleanup):
+        if flush_jounrnal:
+            self.fs.mds_asok(['flush', 'journal'])
+        self.fs.fail()
+        if cleanup:
+            self.remove_openfiles_objects(meta_ioctx)
+            self.fs.journal_tool(["journal", "reset"], 0)
+
+    def restart_mds(self):
+        self.fs.mds_fail_restart()
+        self.fs.set_down(False)
+        self.fs.set_joinable(True)
+        self.fs.wait_for_daemons()
+        status = self.fs.mds_asok(["status"])
+        self.assertEqual("up:active", str(status["state"]))
+        self.mount_a._run_umount_lf()
+        self.mount_a.mount_wait()
+
+    def verify_remote_link_existence(self, mds_rank, test_dir_path):
+        log.info(
+            "verify_remote_link_existence: clearing damage and verifying "
+            "no remote_link entries under %s", test_dir_path)
+        self.fs.mds_asok(["damage", "clear"])
+        success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+        scrub_json = self.tell_command(
+            mds_rank,
+            "scrub start {0} recursive force".format(
+                test_dir_path if test_dir_path.startswith("/") else "/" + test_dir_path),
+            success_validator)
+        self.assertEqual(
+            self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"], sleep=5), True)
+        damage_json = self.tell_command(mds_rank, "damage ls")
+
+        for entry in damage_json:
+            if entry.get("damage_type") == "remote_link":
+                self.fail("unexpected remote_link damage after clear: {0}".format(entry.get("path")))
+        
+        self.fs.mds_asok(["damage", "clear"])
+        # scrub_json = self.tell_command(
+        #     mds_rank,
+        #     "scrub start {0} recursive repair force".format(
+        #         test_dir_path if test_dir_path.startswith("/") else "/" + test_dir_path),
+        #     success_validator)
+        # self.fs.mds_asok(["damage", "clear"])
+        # scrub_json = self.tell_command(
+        #     mds_rank,
+        #     "scrub start {0} recursive force".format(
+        #         test_dir_path if test_dir_path.startswith("/") else "/" + test_dir_path),
+        #     success_validator)
+        # damage_json = self.tell_command(mds_rank, "damage ls")
+        self.fs.mds_asok(['flush', 'journal'])
+
+    def verify_nlink_counts(self, test_dir_path):
+        log.info(
+            "verify_nlink_counts: verifying nlink counts under %s", test_dir_path)
+
+        out = self.mount_a.run_shell([
+            "find", test_dir_path, "-printf", "%i %y %n %p\n"
+        ], stdout=StringIO()).stdout.getvalue()
+
+        file_inode_map = {}
+        file_nlink_map = {}
+        dir_nlink_map = {}
+        dir_paths = set()
+        dir_parent_counts = {}
+
+        for line in out.splitlines():
+            if not line:
+                continue
+            parts = line.split(" ", 3)
+            if len(parts) < 4:
+                continue
+            inode, ftype, nlink, path_str = parts
+            if ftype == "f":
+                file_inode_map.setdefault(inode, set()).add(os.path.basename(path_str))
+                file_nlink_map[inode] = nlink
+            elif ftype == "d":
+                dir_paths.add(path_str)
+                dir_nlink_map[path_str] = nlink
+
+        for dir_path in dir_paths:
+            if dir_path == test_dir_path:
+                continue
+            parent = os.path.dirname(dir_path)
+            if parent in dir_paths:
+                dir_parent_counts[parent] = dir_parent_counts.get(parent, 0) + 1
+
+        file_mismatches = []
+        log.info(
+            "verify_nlink_counts: nlink check files: %d",
+            len(file_inode_map.items()))
+        for inode, names in file_inode_map.items():
+            actual = int(file_nlink_map.get(inode))
+            expected = len(names)
+            log.info(
+                "verify_nlink_counts: file inode %s nlink=%s expected=%s",
+                inode, actual, expected)
+            log.info(
+                "verify_nlink_counts: file inode %s paths: %s",
+                inode, ", ".join(sorted(names)))
+            if actual != expected:
+                file_mismatches.append((inode, expected, actual))
+        if file_mismatches:
+            details = ", ".join(
+                "{0}: expected {1}, got {2}".format(i, e, a)
+                for i, e, a in file_mismatches)
+            self.fail("nlink mismatch for files: {0}".format(details))
+
+        log.info(
+            "verify_nlink_counts: nlink check directories: %d",
+            len(dir_paths))
+        dir_mismatches = []
+        for dir_path in dir_paths:
+            expected_subdirs = dir_parent_counts.get(dir_path, 0)
+            expected_nlink = 2 + expected_subdirs
+            actual = dir_nlink_map.get(dir_path)
+            log.info(
+                "verify_nlink_counts: nlink check %s: expected %d, got %s",
+                dir_path, expected_nlink, actual)
+            if int(actual) != expected_nlink:
+                dir_mismatches.append((dir_path, expected_nlink, actual))
+        if dir_mismatches:
+            details = ", ".join(
+                "{0}: expected {1}, got {2}".format(p, e, a)
+                for p, e, a in dir_mismatches)
+            self.fail("nlink mismatch for directories: {0}".format(details))
+
+    def remove_test_dir_and_verify(self, test_dir_path, meta_ioctx, data_ioctx):
+        log.info(
+            "remove_test_dir_and_verify: removing test directory %s and "
+            "waiting for purges", test_dir_path)
+
+
+        count_out = self.mount_a.run_shell([
+            "find", test_dir_path, "-printf", "%i %y %p\n"
+        ], stdout=StringIO()).stdout.getvalue()
+        inode_types = {}
+        inode_paths = {}
+        for line in count_out.splitlines():
+            if not line:
+                continue
+            parts = line.split(" ", 2)
+            if len(parts) < 3:
+                continue
+            inode_types.setdefault(parts[0], parts[1])
+            inode_paths.setdefault(parts[0], parts[2])
+
+        expected_purges = 0
+        for inode, ftype in inode_types.items():
+            obj = "{0:x}.00000000".format(int(inode))
+            ioctx = meta_ioctx if ftype == "d" else data_ioctx
+            try:
+                ioctx.stat(obj)
+            except rados.ObjectNotFound:
+                log.info(
+                    "remove_test_dir_and_verify: inode object missing: %s path=%s",
+                    inode, inode_paths.get(inode))
+                continue
+            expected_purges += 1
+
+        log.info(
+            "remove_test_dir_and_verify: expected purges (existing inodes): %d",
+            expected_purges)
+
+        self.fs.mds_asok(["flush", "journal"])
+        
+        def strays_cleared():
+            num_strays = self.fs.mds_asok(
+                ["perf", "dump", "mds_cache"])["mds_cache"]["num_strays"]
+            pq_ops = self.fs.mds_asok(
+                ["perf", "dump", "purge_queue"])["purge_queue"]["pq_executing"]
+            log.info(
+                "remove_test_dir_and_verify: num_strays=%d pq_executing=%d",
+                num_strays, pq_ops)
+            return num_strays == 0 and pq_ops == 0
+
+        self.wait_until_true(strays_cleared, timeout=60)
+
+        initial_deletes = self.fs.mds_asok(["perf", "dump", "objecter"])["objecter"]["osdop_delete"]
+
+        self.mount_a.run_shell(["rm", "-rf", test_dir_path])
+        with self.assertRaises(CommandFailedError):
+            self.mount_a.stat(test_dir_path)
+        self.fs.mds_asok(["flush", "journal"])
+
+        def delete_progress():
+            return (self.fs.mds_asok(["perf", "dump", "objecter"])["objecter"]["osdop_delete"]
+                    - initial_deletes)
+
+        def progress_reached():
+            current = delete_progress()
+            log.info(
+                "remove_test_dir_and_verify: osdop_delete progress (after 5s): %d/%d",
+                current, expected_purges)
+            return current >= expected_purges
+
+        self.wait_until_true(progress_reached, timeout=60, period=5)
+
+        for inode, ftype in inode_types.items():
+            obj = "{0:x}.00000000".format(int(inode))
+            ioctx = meta_ioctx if ftype == "d" else data_ioctx
+            try:
+                ioctx.stat(obj)
+            except rados.ObjectNotFound:
+                continue
+            self.fail(
+                "remove_test_dir_and_verify: purge still present: "
+                "inode={0} path={1}".format(
+                    inode, inode_paths.get(inode)))
+
+        status = self.fs.mds_asok(["status"])
+        self.assertEqual("up:active", str(status["state"]))
+
+
+    def inject_damage(self, test_dir_path, build_entry_path, n, b,
+                                        meta_ioctx, data_ioctx):
+        # goal is to make all files in-accessible through path finding
+        # for e_n_[90000...90999] removed e_2_90's metadata from disk
+        # for e_n_[91000...91999] removed e_3_[910...919]'s metadata from disk
+        # for e_n_[92000...92999] removed e_4_[9200...9299]'s metadata from disk
+        # so on...
+        for i in range(b):
+            level = i + 2
+            if level >= n:
+                level = n
+            y = (b - 1) * b + i
+            base = b ** (level - 2)
+            ioctx = data_ioctx if level == n else meta_ioctx
+            for x in range(base):
+                serial = y * base + x
+                print(f"removing directory e_{level}_{serial}'s metadata")
+                entry_path = build_entry_path(test_dir_path, level, serial)
+                ino = self.mount_a.path_to_ino(entry_path)
+                rados_obj = "{ino:x}.00000000".format(ino=ino)
+                ioctx.remove_object(rados_obj)
+
+
+    def verify_remote_link_damage(self, mds_rank, test_dir_path, build_entry_path, n, b, part_span):
+        status = self.fs.mds_asok(["status"])
+        self.assertEqual("up:active", str(status["state"]))
+
+        success_validator = lambda j, r: self.json_validator(j, r, "return_code", 0)
+        scrub_json = self.tell_command(
+            mds_rank,
+            "scrub start {0} recursive force".format(
+                test_dir_path if test_dir_path.startswith("/") else "/" + test_dir_path),
+            success_validator)
+        self.assertEqual(
+            self.fs.wait_until_scrub_complete(tag=scrub_json["scrub_tag"], sleep=5), True)
+
+        damage_json = self.tell_command(mds_rank, "damage ls")
+        remote_link_paths = set(
+            entry["path"] for entry in damage_json
+            if entry.get("damage_type") == "remote_link")
+        remote_link_entries = {
+            entry["path"]: entry for entry in damage_json
+            if entry.get("damage_type") == "remote_link"
+        }
+        missing_links = []
+        hard_link_serial_range = part_span * (b - 1)
+        for serial in range(hard_link_serial_range):
+            link_path = "/" + build_entry_path(test_dir_path, n, serial)
+            if link_path not in remote_link_paths:
+                missing_links.append(link_path)
+        if missing_links:
+            self.fail("missing remote_link damage entries: {0}".format(
+                ", ".join(missing_links)))
+        return remote_link_entries
+
+    def remove_openfiles_objects(self, meta_ioctx):
+        log.info("removing openfiles")
+        x = 0
+        while True:
+            obj_name = "mds0_openfiles.{0}".format(x)
+            try:
+                meta_ioctx.stat(obj_name)
+            except rados.ObjectNotFound:
+                break
+            log.info(
+                "remove_openfiles_objects: removing %s", obj_name)
+            meta_ioctx.remove_object(obj_name)
+            x += 1
+
     def test_stray_evaluation_with_scrub(self):
         """
         test that scrub can iterate over ~mdsdir and evaluate strays
@@ -386,7 +879,7 @@ class TestScrubChecks(CephFSTestCase):
                 jv=element_value, ev=expected_value)
         return True, "Succeeded"
 
-    def tell_command(self, mds_rank, command, validator):
+    def tell_command(self, mds_rank, command, validator=None):
         log.info("Running command '{command}'".format(command=command))
 
         command_list = command.split()
@@ -395,9 +888,10 @@ class TestScrubChecks(CephFSTestCase):
         log.info("command '{command}' returned '{jout}'".format(
                      command=command, jout=jout))
 
-        success, errstring = validator(jout, 0)
-        if not success:
-            raise AsokCommandFailedError(command, 0, jout, errstring)
+        if validator:
+            success, errstring = validator(jout, 0)
+            if not success:
+                raise AsokCommandFailedError(command, 0, jout, errstring)
         return jout
 
     def asok_command(self, mds_rank, command, validator):

--- a/src/cls/cephfs/cls_cephfs.cc
+++ b/src/cls/cephfs/cls_cephfs.cc
@@ -122,6 +122,48 @@ static int accumulate_inode_metadata(cls_method_context_t hctx,
   return 0;
 }
 
+static int set_accumulated_inode_metadata(cls_method_context_t hctx,
+                                          bufferlist *in, bufferlist *out) {
+  ceph_assert(in != NULL);
+  ceph_assert(out != NULL);
+
+  auto q = in->cbegin();
+  SetAccumulatedArgs args;
+  try {
+    args.decode(q);
+  } catch (const ceph::buffer::error &err) {
+    return -EINVAL;
+  }
+
+  int r = 0;
+  ObjCeiling ceiling(args.ceiling_obj_index, args.ceiling_obj_size);
+  r = set_if_greater(hctx, args.obj_xattr_name, ceiling);
+  if (r < 0) {
+    return r;
+  }
+
+  r = set_if_greater(hctx, args.mtime_xattr_name, args.max_mtime);
+  if (r < 0) {
+    return r;
+  }
+
+  r = set_if_greater(hctx, args.obj_size_xattr_name, args.max_obj_size);
+  if (r < 0) {
+    return r;
+  }
+
+  if (args.has_pool_id) {
+    bufferlist pool_id_bl;
+    encode(args.obj_pool_id, pool_id_bl);
+    r = cls_cxx_setxattr(hctx, args.pool_id_xattr_name.c_str(), &pool_id_bl);
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  return 0;
+}
+
 // I want to select objects that have a name ending 00000000
 // and an xattr (scrub_tag) not equal to a specific value.
 // This is so special case that we can't really pretend it's
@@ -129,8 +171,9 @@ static int accumulate_inode_metadata(cls_method_context_t hctx,
 class PGLSCephFSFilter : public PGLSFilter {
 protected:
   std::string scrub_tag;
+
 public:
-  int init(bufferlist::const_iterator& params) override {
+  int init(bufferlist::const_iterator &params) override {
     try {
       InodeTagFilterArgs args;
       args.decode(params);
@@ -202,13 +245,16 @@ CLS_INIT(cephfs)
 
   cls_handle_t h_class;
   cls_method_handle_t h_accumulate_inode_metadata;
+  cls_method_handle_t h_set_accumulated_inode_metadata;
 
   cls_register("cephfs", &h_class);
-  cls_register_cxx_method(h_class, "accumulate_inode_metadata",
-			  CLS_METHOD_WR | CLS_METHOD_RD,
-			  accumulate_inode_metadata, &h_accumulate_inode_metadata);
+  cls_register_cxx_method(
+      h_class, "accumulate_inode_metadata", CLS_METHOD_WR | CLS_METHOD_RD,
+      accumulate_inode_metadata, &h_accumulate_inode_metadata);
+  cls_register_cxx_method(
+      h_class, "set_accumulated_inode_metadata", CLS_METHOD_WR | CLS_METHOD_RD,
+      set_accumulated_inode_metadata, &h_set_accumulated_inode_metadata);
 
   // A PGLS filter
   cls_register_cxx_filter(h_class, "inode_tag", inode_tag_filter);
 }
-

--- a/src/cls/cephfs/cls_cephfs.h
+++ b/src/cls/cephfs/cls_cephfs.h
@@ -108,6 +108,71 @@ public:
   }
 };
 
+class SetAccumulatedArgs {
+public:
+  uint64_t ceiling_obj_index;
+  uint64_t ceiling_obj_size;
+  uint64_t max_obj_size;
+  int64_t max_mtime;
+  bool has_pool_id;
+  int64_t obj_pool_id;
+  std::string obj_xattr_name;
+  std::string mtime_xattr_name;
+  std::string obj_size_xattr_name;
+  std::string pool_id_xattr_name;
+
+  SetAccumulatedArgs(uint64_t ceiling_obj_index_, uint64_t ceiling_obj_size_,
+                    uint64_t max_obj_size_, int64_t max_mtime_,
+                    bool has_pool_id_, int64_t obj_pool_id_,
+                    const std::string &obj_xattr_name_,
+                    const std::string &mtime_xattr_name_,
+                    const std::string &obj_size_xattr_name_,
+                    const std::string &pool_id_xattr_name_)
+      : ceiling_obj_index(ceiling_obj_index_),
+        ceiling_obj_size(ceiling_obj_size_), max_obj_size(max_obj_size_),
+        max_mtime(max_mtime_), has_pool_id(has_pool_id_),
+        obj_pool_id(obj_pool_id_), obj_xattr_name(obj_xattr_name_),
+        mtime_xattr_name(mtime_xattr_name_),
+        obj_size_xattr_name(obj_size_xattr_name_),
+        pool_id_xattr_name(pool_id_xattr_name_) {}
+
+  SetAccumulatedArgs()
+      : ceiling_obj_index(0), ceiling_obj_size(0), max_obj_size(0),
+        max_mtime(0), has_pool_id(false), obj_pool_id(-1) {}
+
+  void encode(ceph::buffer::list &bl) const
+  {
+    ENCODE_START(1, 1, bl);
+    encode(ceiling_obj_index, bl);
+    encode(ceiling_obj_size, bl);
+    encode(max_obj_size, bl);
+    encode(max_mtime, bl);
+    encode(has_pool_id, bl);
+    encode(obj_pool_id, bl);
+    encode(obj_xattr_name, bl);
+    encode(mtime_xattr_name, bl);
+    encode(obj_size_xattr_name, bl);
+    encode(pool_id_xattr_name, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(ceph::buffer::list::const_iterator &bl)
+  {
+    DECODE_START(1, bl);
+    decode(ceiling_obj_index, bl);
+    decode(ceiling_obj_size, bl);
+    decode(max_obj_size, bl);
+    decode(max_mtime, bl);
+    decode(has_pool_id, bl);
+    decode(obj_pool_id, bl);
+    decode(obj_xattr_name, bl);
+    decode(mtime_xattr_name, bl);
+    decode(obj_size_xattr_name, bl);
+    decode(pool_id_xattr_name, bl);
+    DECODE_FINISH(bl);
+  }
+};
+
 class InodeTagFilterArgs
 {
   public:
@@ -147,4 +212,3 @@ public:
       obj_pool_id(-1), max_mtime(0)
   {}
 };
-

--- a/src/cls/cephfs/cls_cephfs_client.cc
+++ b/src/cls/cephfs/cls_cephfs_client.cc
@@ -27,50 +27,21 @@ using ceph::decode;
 #define XATTR_MAX_SIZE "scan_max_size"
 #define XATTR_POOL_ID "scan_pool_id"
 
-namespace {
-
-void update_accumulate_result(AccumulateResult *accum_res,
-                              const uint64_t obj_index, const uint64_t obj_size,
-                              const int64_t obj_pool_id, const time_t mtime) {
-  ceph_assert(accum_res != nullptr);
-
-  if (obj_index > accum_res->ceiling_obj_index ||
-      (obj_index == accum_res->ceiling_obj_index &&
-       accum_res->ceiling_obj_size == 0)) {
-    accum_res->ceiling_obj_index = obj_index;
-    accum_res->ceiling_obj_size = obj_size;
-  }
-
-  if (obj_size > accum_res->max_obj_size) {
-    accum_res->max_obj_size = obj_size;
-  }
-
-  if (mtime > accum_res->max_mtime) {
-    accum_res->max_mtime = mtime;
-  }
-
-  if (obj_pool_id != -1) {
-    accum_res->obj_pool_id = obj_pool_id;
-  }
-}
-
-} // namespace
-
 int ClsCephFSClient::accumulate_inode_metadata(
-    librados::IoCtx &ctx, inodeno_t inode_no, const uint64_t obj_index,
-    const uint64_t obj_size, const int64_t obj_pool_id, const time_t mtime,
-    AccumulateResult *accum_res, const bool immediate_write) {
-  if (!immediate_write) {
-    if (accum_res == nullptr) {
-      return -EINVAL;
-    }
-    update_accumulate_result(accum_res, obj_index, obj_size, obj_pool_id,
-                             mtime);
-    return 0;
-  }
-
-  AccumulateArgs args(obj_index, obj_size, mtime, XATTR_CEILING,
-                      XATTR_MAX_MTIME, XATTR_MAX_SIZE);
+  librados::IoCtx &ctx,
+  inodeno_t inode_no,
+  const uint64_t obj_index,
+  const uint64_t obj_size,
+  const int64_t obj_pool_id,
+  const time_t mtime)
+{
+  AccumulateArgs args(
+      obj_index,
+      obj_size,
+      mtime,
+      XATTR_CEILING,
+      XATTR_MAX_MTIME,
+      XATTR_MAX_SIZE);
 
   // Generate 0th object name, where we will accumulate sizes/mtimes
   object_t zeroth_object = InodeStore::get_object_name(inode_no, frag_t(), "");

--- a/src/cls/cephfs/cls_cephfs_client.cc
+++ b/src/cls/cephfs/cls_cephfs_client.cc
@@ -27,21 +27,50 @@ using ceph::decode;
 #define XATTR_MAX_SIZE "scan_max_size"
 #define XATTR_POOL_ID "scan_pool_id"
 
+namespace {
+
+void update_accumulate_result(AccumulateResult *accum_res,
+                              const uint64_t obj_index, const uint64_t obj_size,
+                              const int64_t obj_pool_id, const time_t mtime) {
+  ceph_assert(accum_res != nullptr);
+
+  if (obj_index > accum_res->ceiling_obj_index ||
+      (obj_index == accum_res->ceiling_obj_index &&
+       accum_res->ceiling_obj_size == 0)) {
+    accum_res->ceiling_obj_index = obj_index;
+    accum_res->ceiling_obj_size = obj_size;
+  }
+
+  if (obj_size > accum_res->max_obj_size) {
+    accum_res->max_obj_size = obj_size;
+  }
+
+  if (mtime > accum_res->max_mtime) {
+    accum_res->max_mtime = mtime;
+  }
+
+  if (obj_pool_id != -1) {
+    accum_res->obj_pool_id = obj_pool_id;
+  }
+}
+
+} // namespace
+
 int ClsCephFSClient::accumulate_inode_metadata(
-  librados::IoCtx &ctx,
-  inodeno_t inode_no,
-  const uint64_t obj_index,
-  const uint64_t obj_size,
-  const int64_t obj_pool_id,
-  const time_t mtime)
-{
-  AccumulateArgs args(
-      obj_index,
-      obj_size,
-      mtime,
-      XATTR_CEILING,
-      XATTR_MAX_MTIME,
-      XATTR_MAX_SIZE);
+    librados::IoCtx &ctx, inodeno_t inode_no, const uint64_t obj_index,
+    const uint64_t obj_size, const int64_t obj_pool_id, const time_t mtime,
+    AccumulateResult *accum_res, const bool immediate_write) {
+  if (!immediate_write) {
+    if (accum_res == nullptr) {
+      return -EINVAL;
+    }
+    update_accumulate_result(accum_res, obj_index, obj_size, obj_pool_id,
+                             mtime);
+    return 0;
+  }
+
+  AccumulateArgs args(obj_index, obj_size, mtime, XATTR_CEILING,
+                      XATTR_MAX_MTIME, XATTR_MAX_SIZE);
 
   // Generate 0th object name, where we will accumulate sizes/mtimes
   object_t zeroth_object = InodeStore::get_object_name(inode_no, frag_t(), "");
@@ -59,6 +88,24 @@ int ClsCephFSClient::accumulate_inode_metadata(
   }
 
   // Execute op
+  return ctx.operate(zeroth_object.name, &op);
+}
+
+int ClsCephFSClient::flush_inode_accumulate_result(
+    librados::IoCtx &ctx, inodeno_t inode_no,
+    const AccumulateResult &accum_res) {
+  object_t zeroth_object = InodeStore::get_object_name(inode_no, frag_t(), "");
+
+  SetAccumulatedArgs args(accum_res.ceiling_obj_index,
+                          accum_res.ceiling_obj_size, accum_res.max_obj_size,
+                          accum_res.max_mtime, accum_res.obj_pool_id != -1,
+                          accum_res.obj_pool_id, XATTR_CEILING, XATTR_MAX_MTIME,
+                          XATTR_MAX_SIZE, XATTR_POOL_ID);
+  librados::ObjectWriteOperation op;
+  bufferlist inbl;
+  args.encode(inbl);
+  op.exec("cephfs", "set_accumulated_inode_metadata", inbl);
+
   return ctx.operate(zeroth_object.name, &op);
 }
 

--- a/src/cls/cephfs/cls_cephfs_client.h
+++ b/src/cls/cephfs/cls_cephfs_client.h
@@ -10,12 +10,13 @@ class AccumulateArgs;
 class ClsCephFSClient
 {
   public:
-  static int
-  accumulate_inode_metadata(librados::IoCtx &ctx, inodeno_t inode_no,
-                            const uint64_t obj_index, const uint64_t obj_size,
-                            const int64_t obj_pool_id, const time_t mtime,
-                            AccumulateResult *accum_res = nullptr,
-                            const bool immediate_write = true);
+  static int accumulate_inode_metadata(
+      librados::IoCtx &ctx,
+      inodeno_t inode_no,
+      const uint64_t obj_index,
+      const uint64_t obj_size,
+      const int64_t obj_pool_id,
+      const time_t mtime);
 
   static int flush_inode_accumulate_result(librados::IoCtx &ctx,
                                             inodeno_t inode_no,

--- a/src/cls/cephfs/cls_cephfs_client.h
+++ b/src/cls/cephfs/cls_cephfs_client.h
@@ -10,13 +10,16 @@ class AccumulateArgs;
 class ClsCephFSClient
 {
   public:
-  static int accumulate_inode_metadata(
-      librados::IoCtx &ctx,
-      inodeno_t inode_no,
-      const uint64_t obj_index,
-      const uint64_t obj_size,
-      const int64_t obj_pool_id,
-      const time_t mtime);
+  static int
+  accumulate_inode_metadata(librados::IoCtx &ctx, inodeno_t inode_no,
+                            const uint64_t obj_index, const uint64_t obj_size,
+                            const int64_t obj_pool_id, const time_t mtime,
+                            AccumulateResult *accum_res = nullptr,
+                            const bool immediate_write = true);
+
+  static int flush_inode_accumulate_result(librados::IoCtx &ctx,
+                                            inodeno_t inode_no,
+                                            const AccumulateResult &accum_res);
 
   static int fetch_inode_accumulate_result(
       librados::IoCtx &ctx,

--- a/src/common/options/mds.yaml.in
+++ b/src/common/options/mds.yaml.in
@@ -1555,3 +1555,27 @@ options:
   - mds
   flags:
   - runtime
+- name: mds_damage_log_to_file
+  type: bool
+  level: advanced
+  desc: send mds damage lines to a file
+  fmt_desc: Determines if damages should appear in a file.
+  default: false
+  see_also:
+  - log_file
+  with_legacy: true
+- name: mds_damage_log_file
+  type: str
+  level: advanced
+  desc: path to log file where damage will be written
+  fmt_desc: The location of the logging file for where damage of mds will be written.
+  daemon_default: /var/log/ceph/$cluster-$name-damages.log
+  with_legacy: true
+- name: mds_force_hard_link_scrubbing
+  type: bool
+  level: advanced
+  desc: force scrubbing hard link
+  default: false
+  services:
+  - mds
+  with_legacy: true

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2007,7 +2007,7 @@ void CDir::_omap_fetched(bufferlist &hdrbl, map<string, bufferlist> &omap,
     clog->error() << "dir " << dirfrag() << " object missing on disk; some "
                      "files may be lost (" << get_path() << ")";
 
-    go_bad(complete | from_scrub);
+    go_bad(complete || from_scrub);
     return;
   }
 
@@ -2021,14 +2021,14 @@ void CDir::_omap_fetched(bufferlist &hdrbl, map<string, bufferlist> &omap,
 	   << ": " << err.what() << dendl;
       clog->warn() << "Corrupt fnode header in " << dirfrag() << ": "
 		   << err.what() << " (" << get_path() << ")";
-      go_bad(complete | from_scrub);
+      go_bad(complete || from_scrub);
       return;
     }
     if (!p.end()) {
       clog->warn() << "header buffer of dir " << dirfrag() << " has "
 		  << hdrbl.length() - p.get_off() << " extra bytes ("
                   << get_path() << ")";
-      go_bad(complete | from_scrub);
+      go_bad(complete || from_scrub);
       return;
     }
   }

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -483,7 +483,8 @@ public:
   void fetch(MDSContext *c, bool ignore_authpinnability=false) {
     fetch("", CEPH_NOSNAP, c, ignore_authpinnability);
   }
-  void fetch_keys(const std::vector<dentry_key_t>& keys, MDSContext *c);
+  void fetch_keys(const std::vector<dentry_key_t> &keys, MDSContext *c,
+                  bool from_scrub = false);
 
 #if 0  // unused?
   void wait_for_commit(Context *c, version_t v=0);
@@ -653,7 +654,8 @@ protected:
   friend class C_IO_Dir_Committed;
   friend class C_IO_Dir_Commit_Ops;
 
-  void _omap_fetch(std::set<std::string> *keys, MDSContext *fin=nullptr);
+  void _omap_fetch(std::set<std::string> *keys, MDSContext *fin = nullptr,
+                   bool from_scrub = false);
   void _omap_fetch_more(version_t omap_version, bufferlist& hdrbl,
 			std::map<std::string, bufferlist>& omap, MDSContext *fin);
   CDentry *_load_dentry(
@@ -671,8 +673,10 @@ protected:
    */
   void go_bad(bool complete);
 
-  void _omap_fetched(ceph::buffer::list& hdrbl, std::map<std::string, ceph::buffer::list>& omap,
-		     bool complete, const std::set<std::string>& keys, int r);
+  void _omap_fetched(ceph::buffer::list &hdrbl,
+                     std::map<std::string, ceph::buffer::list> &omap,
+                     bool complete, const std::set<std::string> &keys, int r,
+                     bool from_scrub = false);
 
   // -- commit --
   void _commit(version_t want, int op_prio);

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -5198,7 +5198,6 @@ void CInode::scrub_info_create() const
 {
   dout(25) << __func__ << dendl;
   ceph_assert(!scrub_infop);
-
   // break out of const-land to set up implicit initial state
   CInode *me = const_cast<CInode*>(this);
   const auto& pi = me->get_projected_inode();
@@ -5231,23 +5230,46 @@ void CInode::scrub_initialize(ScrubHeaderRef& header)
   // right now we don't handle remote inodes
 }
 
+void CInode::set_forward_scrub(bool forward_scrub) {
+  scrub_infop->forward_scrub = forward_scrub;
+}
+
+void CInode::scrub_add_remote_link(
+    std::vector<std::pair<std::string, inodeno_t>> &&remote_links) {
+
+  for (auto &p : remote_links) {
+    scrub_infop->remote_links.emplace_back(std::move(p));
+  }
+}
+
+void CInode::scrub_reset_remote_links() {
+  scrub_infop->remote_links.clear();
+}
+
+std::vector<std::pair<std::string, inodeno_t>> &&
+CInode::scrub_move_remote_links() {
+  return std::move(scrub_infop->remote_links);
+}
+
 void CInode::scrub_aborted() {
   dout(20) << __func__ << dendl;
   ceph_assert(scrub_is_in_progress());
-
   scrub_infop->scrub_in_progress = false;
   scrub_infop->header->dec_num_pending();
+  scrub_infop->remote_links.clear();
+  scrub_infop->forward_scrub = true;
   scrub_maybe_delete_info();
 }
 
 void CInode::scrub_finished() {
   dout(20) << __func__ << dendl;
   ceph_assert(scrub_is_in_progress());
-
   scrub_infop->last_scrub_version = get_version();
   scrub_infop->last_scrub_stamp = ceph_clock_now();
   scrub_infop->last_scrub_dirty = true;
   scrub_infop->scrub_in_progress = false;
+  scrub_infop->remote_links.clear();
+  scrub_infop->forward_scrub = true;
   scrub_infop->header->dec_num_pending();
 }
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -5218,36 +5218,40 @@ void CInode::scrub_maybe_delete_info()
   }
 }
 
-void CInode::scrub_initialize(ScrubHeaderRef& header)
-{
+void CInode::scrub_initialize(ScrubHeaderRef &header,
+                              std::vector<remote_link_info_t> &&remote_links) {
   dout(20) << __func__ << " with scrub_version " << get_version() << dendl;
 
   scrub_info();
   scrub_infop->scrub_in_progress = true;
   scrub_infop->queued_frags.clear();
   scrub_infop->header = header;
+  if (!remote_links.empty()) {
+    scrub_infop->remote_links.swap(remote_links);
+    scrub_infop->forward_scrub = false;
+  }
   header->inc_num_pending();
   // right now we don't handle remote inodes
 }
 
-void CInode::set_forward_scrub(bool forward_scrub) {
-  scrub_infop->forward_scrub = forward_scrub;
-}
-
-void CInode::scrub_add_remote_link(
-    std::vector<std::pair<std::string, inodeno_t>> &&remote_links) {
-
-  for (auto &p : remote_links) {
-    scrub_infop->remote_links.emplace_back(std::move(p));
+bool CInode::maybe_update_scrub_in_progress(
+    std::vector<remote_link_info_t> &&remote_links) {
+  bool ret = false;
+  if (scrub_is_in_progress()) {
+    if (!remote_links.empty()) {
+      for (auto& p : remote_links) {
+	scrub_infop->remote_links.emplace_back(std::move(p));
+      }
+      //leaving forward mode as-is
+    } else {
+      scrub_infop->forward_scrub = true; //[re-]request forward mode, it's fine if it's already been requested
+    }
+    ret = true;
   }
+  return ret;
 }
 
-void CInode::scrub_reset_remote_links() {
-  scrub_infop->remote_links.clear();
-}
-
-std::vector<std::pair<std::string, inodeno_t>> &&
-CInode::scrub_move_remote_links() {
+std::vector<CInode::remote_link_info_t> &&CInode::scrub_move_remote_links() {
   return std::move(scrub_infop->remote_links);
 }
 

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -305,6 +305,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
     bool last_scrub_dirty = false; /// are our stamps dirty with respect to disk state?
     bool scrub_in_progress = false; /// are we currently scrubbing?
+    std::vector<std::pair<std::string, inodeno_t>> remote_links;
+    bool forward_scrub = true;
 
     fragset_t queued_frags;
 
@@ -457,6 +459,15 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void scrub_finished();
 
   void scrub_aborted();
+
+  void scrub_add_remote_link(
+      std::vector<std::pair<std::string, inodeno_t>> &&remote_links);
+
+  void scrub_reset_remote_links();
+
+  std::vector<std::pair<std::string, inodeno_t>> &&scrub_move_remote_links();
+
+  void set_forward_scrub(bool forward_scrub);
 
   fragset_t& scrub_queued_frags() {
     ceph_assert(scrub_infop);

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -296,6 +296,21 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   friend class CDir;
   friend std::ostream& operator<<(std::ostream&, const CInode&);
 
+  struct remote_link_info_t {
+    std::string path;
+    inodeno_t ino;
+    inodeno_t parent_ino;
+
+    remote_link_info_t() {}
+
+    remote_link_info_t(const std::string &path, inodeno_t ino,
+                       inodeno_t parent_ino)
+        : path(path), ino(ino), parent_ino(parent_ino) {}
+
+    remote_link_info_t(std::string &&path, inodeno_t ino, inodeno_t parent_ino)
+        : path(std::move(path)), ino(ino), parent_ino(parent_ino) {}
+  };
+
   class scrub_info_t {
   public:
     scrub_info_t() {}
@@ -305,7 +320,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
     bool last_scrub_dirty = false; /// are our stamps dirty with respect to disk state?
     bool scrub_in_progress = false; /// are we currently scrubbing?
-    std::vector<std::pair<std::string, inodeno_t>> remote_links;
+    std::vector<remote_link_info_t> remote_links;
     bool forward_scrub = true;
 
     fragset_t queued_frags;
@@ -448,7 +463,18 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
    * @param scrub_version What version are we scrubbing at (usually, parent
    * directory's get_projected_version())
    */
-  void scrub_initialize(ScrubHeaderRef& header);
+  void scrub_initialize(ScrubHeaderRef &header,
+                        std::vector<remote_link_info_t> &&remote_links = {});
+
+  bool maybe_update_scrub_in_progress(
+      std::vector<remote_link_info_t> &&remote_links = {});
+
+  void reset_forward_scrub() {
+    if (scrub_infop) {
+      scrub_infop->forward_scrub = false;
+    }
+  }
+
   /**
    * Call this once the scrub has been completed, whether it's a full
    * recursive scrub on a directory or simply the data on a file (or
@@ -460,14 +486,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   void scrub_aborted();
 
-  void scrub_add_remote_link(
-      std::vector<std::pair<std::string, inodeno_t>> &&remote_links);
-
-  void scrub_reset_remote_links();
-
-  std::vector<std::pair<std::string, inodeno_t>> &&scrub_move_remote_links();
-
-  void set_forward_scrub(bool forward_scrub);
+  std::vector<remote_link_info_t> &&scrub_move_remote_links();
 
   fragset_t& scrub_queued_frags() {
     ceph_assert(scrub_infop);

--- a/src/mds/DamageTable.cc
+++ b/src/mds/DamageTable.cc
@@ -133,9 +133,11 @@ class BacktraceDamage : public DamageEntry
 class RemoteLinkDamage : public DamageEntry {
 public:
   inodeno_t ino;
+  inodeno_t parent_ino;
   std::string head_path;
-  RemoteLinkDamage(inodeno_t ino_, const std::string &head_path_ = "")
-      : ino(ino_), head_path(head_path_) {}
+  RemoteLinkDamage(inodeno_t ino_, inodeno_t parent_ino_,
+                   const std::string &head_path_ = "")
+      : ino(ino_), parent_ino(parent_ino_), head_path(head_path_) {}
 
   damage_entry_type_t get_type() const override {
     return DAMAGE_ENTRY_REMOTE_LINK;
@@ -146,6 +148,7 @@ public:
     f->dump_string("damage_type", "remote_link");
     f->dump_int("id", id);
     f->dump_int("ino", ino);
+    f->dump_int("parent_ino", parent_ino);
     f->dump_string("path", path);
     f->dump_string("head_path", head_path);
     f->close_section();
@@ -252,6 +255,7 @@ bool DamageTable::notify_remote_damaged(inodeno_t ino, std::string_view path)
 }
 
 bool DamageTable::notify_remote_link_damaged(inodeno_t ino,
+                                             inodeno_t parent_ino,
                                              const std::string &path,
                                              const std::string &head_path) {
   bool over_sized = oversized();
@@ -259,7 +263,7 @@ bool DamageTable::notify_remote_link_damaged(inodeno_t ino,
     return true;
   }
 
-  auto entry = std::make_shared<RemoteLinkDamage>(ino, head_path);
+  auto entry = std::make_shared<RemoteLinkDamage>(ino, parent_ino, head_path);
   entry->path = path;
   if (log_to_file && log_file_opened) {
     fout << *entry << std::endl;

--- a/src/mds/DamageTable.cc
+++ b/src/mds/DamageTable.cc
@@ -29,6 +29,12 @@ namespace {
  * Record damage to a particular dirfrag, implicitly affecting
  * any dentries within it.
  */
+inline std::ostream& operator<<(std::ostream& os, const DamageEntry& entry)
+{
+  entry.print(os);
+  return os;
+}
+
 class DirFragDamage : public DamageEntry
 {
   public:
@@ -123,6 +129,28 @@ class BacktraceDamage : public DamageEntry
     f->close_section();
   }
 };
+
+class RemoteLinkDamage : public DamageEntry {
+public:
+  inodeno_t ino;
+  std::string head_path;
+  RemoteLinkDamage(inodeno_t ino_, const std::string &head_path_ = "")
+      : ino(ino_), head_path(head_path_) {}
+
+  damage_entry_type_t get_type() const override {
+    return DAMAGE_ENTRY_REMOTE_LINK;
+  }
+
+  void dump(Formatter *f) const override {
+    f->open_object_section("remote_link_damage");
+    f->dump_string("damage_type", "remote_link");
+    f->dump_int("id", id);
+    f->dump_int("ino", ino);
+    f->dump_string("path", path);
+    f->dump_string("head_path", head_path);
+    f->close_section();
+  }
+};
 }
 
 DamageEntry::~DamageEntry()
@@ -132,28 +160,34 @@ bool DamageTable::notify_dentry(
     inodeno_t ino, frag_t frag,
     snapid_t snap_id, std::string_view dname, std::string_view path)
 {
-  if (oversized()) {
+  bool over_sized = oversized();
+  if (!log_to_file && over_sized) {
     return true;
   }
 
   // Special cases: damage to these dirfrags is considered fatal to
   // the MDS rank that owns them.
-  if (
-      (MDS_INO_IS_MDSDIR(ino) && MDS_INO_MDSDIR_OWNER(ino) == rank)
-      ||
-      (MDS_INO_IS_STRAY(ino) && MDS_INO_STRAY_OWNER(ino) == rank)
-     ) {
+  if ((MDS_INO_IS_MDSDIR(ino) && MDS_INO_MDSDIR_OWNER(ino) == rank) ||
+      (MDS_INO_IS_STRAY(ino) && MDS_INO_STRAY_OWNER(ino) == rank)) {
     derr << "Damage to dentries in fragment " << frag << " of ino " << ino
          << "is fatal because it is a system directory for this rank" << dendl;
     return true;
   }
 
-  auto& df_dentries = dentries[DirFragIdent(ino, frag)];
-  if (auto [it, inserted] = df_dentries.try_emplace(DentryIdent(dname, snap_id)); inserted) {
-    auto entry = std::make_shared<DentryDamage>(ino, frag, dname, snap_id);
-    entry->path = path;
-    it->second = entry;
-    by_id[entry->id] = std::move(entry);
+  auto entry = std::make_shared<DentryDamage>(ino, frag, dname, snap_id);
+  entry->path = path;
+  if (log_to_file && log_file_opened) {
+    fout << *entry << std::endl;
+  }
+
+  if (!over_sized) {
+    auto &df_dentries = dentries[DirFragIdent(ino, frag)];
+    if (auto [it, inserted] =
+            df_dentries.try_emplace(DentryIdent(dname, snap_id));
+        inserted) {
+      it->second = entry;
+      by_id[entry->id] = std::move(entry);
+    }
   }
 
   return false;
@@ -171,15 +205,24 @@ bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag,
     return true;
   }
 
-  if (oversized()) {
+  bool over_sized = oversized();
+
+  if (!log_to_file && over_sized) {
     return true;
   }
 
-  if (auto [it, inserted] = dirfrags.try_emplace(DirFragIdent(ino, frag)); inserted) {
-    DamageEntryRef entry = std::make_shared<DirFragDamage>(ino, frag);
-    entry->path = path;
-    it->second = entry;
-    by_id[entry->id] = std::move(entry);
+  DamageEntryRef entry = std::make_shared<DirFragDamage>(ino, frag);
+  entry->path = path;
+  if (log_to_file && log_file_opened) {
+    fout << *entry << std::endl;
+  }
+
+  if (!over_sized) {
+    if (auto [it, inserted] = dirfrags.try_emplace(DirFragIdent(ino, frag));
+        inserted) {
+      it->second = entry;
+      by_id[entry->id] = std::move(entry);
+    }
   }
 
   return false;
@@ -187,15 +230,47 @@ bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag,
 
 bool DamageTable::notify_remote_damaged(inodeno_t ino, std::string_view path)
 {
-  if (oversized()) {
+  bool over_sized = oversized();
+  if (!log_to_file && over_sized) {
     return true;
   }
 
-  if (auto [it, inserted] = remotes.try_emplace(ino); inserted) {
-    auto entry = std::make_shared<BacktraceDamage>(ino);
-    entry->path = path;
-    it->second = entry;
-    by_id[entry->id] = std::move(entry);
+  auto entry = std::make_shared<BacktraceDamage>(ino);
+  entry->path = path;
+  if (log_to_file && log_file_opened) {
+    fout << *entry << std::endl;
+  }
+
+  if (!over_sized) {
+    if (auto [it, inserted] = remotes.try_emplace(ino); inserted) {
+      it->second = entry;
+      by_id[entry->id] = std::move(entry);
+    }
+  }
+
+  return false;
+}
+
+bool DamageTable::notify_remote_link_damaged(inodeno_t ino,
+                                             const std::string &path,
+                                             const std::string &head_path) {
+  bool over_sized = oversized();
+  if (!log_to_file && over_sized) {
+    return true;
+  }
+
+  auto entry = std::make_shared<RemoteLinkDamage>(ino, head_path);
+  entry->path = path;
+  if (log_to_file && log_file_opened) {
+    fout << *entry << std::endl;
+  }
+
+  if (!over_sized) {
+    auto& df_remote_links = remote_links[ino];
+    if (auto [it, inserted] = df_remote_links.try_emplace(path); inserted) {
+      it->second = entry;
+      by_id[entry->id] = std::move(entry);
+    }
   }
 
   return false;
@@ -263,6 +338,10 @@ bool DamageTable::is_remote_damaged(
   return remotes.count(ino) > 0;
 }
 
+bool DamageTable::is_remote_link_damaged(const inodeno_t ino) const {
+  return remote_links.count(ino) > 0;
+}
+
 void DamageTable::dump(Formatter *f) const
 {
   f->open_array_section("damage_table");
@@ -293,6 +372,15 @@ void DamageTable::erase(damage_entry_id_t damage_id)
   } else if (type == DAMAGE_ENTRY_BACKTRACE) {
     auto backtrace_entry = std::static_pointer_cast<BacktraceDamage>(entry);
     remotes.erase(backtrace_entry->ino);
+  } else if (type == DAMAGE_ENTRY_REMOTE_LINK) {
+    auto remote_link_entry = std::static_pointer_cast<RemoteLinkDamage>(entry);
+    auto df_remote_link_it = remote_links.find(remote_link_entry->ino);
+    if (df_remote_link_it != remote_links.end()) {
+      df_remote_link_it->second.erase(entry->path);
+      if(df_remote_link_it->second.empty()) {
+        remote_links.erase(df_remote_link_it);
+      }
+    }
   } else {
     derr << "Invalid type " << type << dendl;
     ceph_abort();
@@ -301,3 +389,64 @@ void DamageTable::erase(damage_entry_id_t damage_id)
   by_id.erase(by_id_entry);
 }
 
+void DamageTable::open_damage_log_file(std::ofstream &fout,
+                                       const std::filesystem::path &file_path) {
+  namespace fs = std::filesystem;
+  close_damage_log_file();
+  const fs::path dir = file_path.parent_path();
+
+  if (!dir.empty()) {
+    std::error_code ec;
+
+    if (!fs::exists(dir, ec)) {
+      if (ec) {
+        derr << "error checking existence of damage dir: " << dir << " ("
+             << ec.message() << ")" << dendl;
+        return;
+      }
+
+      if (!fs::create_directories(dir, ec)) {
+        derr << "failed to create directories for damage file: " << dir << " ("
+             << ec.message() << ")" << dendl;
+        return;
+      }
+    }
+  }
+
+  fout.open(file_path, std::ios::out | std::ios::app);
+
+  if (!fout.is_open()) {
+    derr << "failed to open damage file: " << file_path << dendl;
+    return;
+  }
+
+  log_file_opened = true;
+}
+
+void DamageTable::close_damage_log_file() {
+  if (fout.is_open()) {
+    fout.close();
+  }
+  fout.clear();
+  log_file_opened = false;
+}
+
+void DamageTable::clear() {
+  dirfrags.clear();
+  dentries.clear();
+  remotes.clear();
+  remote_links.clear();
+  by_id.clear();
+  if (log_to_file && log_file_opened) {
+    if (fout.is_open()) {
+      fout.close();
+      fout.open(log_file, std::ios::out | std::ios::trunc);
+      fout.close();
+    }
+    fout.open(log_file, std::ios::out | std::ios::app);
+    if (!fout.is_open()) {
+      log_file_opened = false;
+      derr << "failed to open damage file: " << log_file << dendl;
+    }
+  }
+}

--- a/src/mds/DamageTable.h
+++ b/src/mds/DamageTable.h
@@ -16,8 +16,12 @@
 #ifndef DAMAGE_TABLE_H_
 #define DAMAGE_TABLE_H_
 
+#include <filesystem>
+#include <fstream>
+#include <ostream>
 #include <string_view>
 
+#include "common/Formatter.h"
 #include "mdstypes.h"
 #include "include/random.h"
 
@@ -30,7 +34,8 @@ typedef enum
 {
   DAMAGE_ENTRY_DIRFRAG,
   DAMAGE_ENTRY_DENTRY,
-  DAMAGE_ENTRY_BACKTRACE
+  DAMAGE_ENTRY_BACKTRACE,
+  DAMAGE_ENTRY_REMOTE_LINK
 
 } damage_entry_type_t;
 
@@ -47,6 +52,11 @@ class DamageEntry
 
     virtual damage_entry_type_t get_type() const = 0;
     virtual void dump(Formatter *f) const = 0;
+    void print(std::ostream &os) const {
+      JSONFormatter jf;
+      dump(&jf);
+      jf.flush(os);
+    }
 
     damage_entry_id_t id;
     utime_t reported_at;
@@ -121,10 +131,13 @@ class DentryIdent
 class DamageTable
 {
   public:
-    explicit DamageTable(const mds_rank_t rank_)
-      : rank(rank_)
-    {
+    explicit DamageTable(const mds_rank_t rank_, bool log_to_file_,
+                         const std::string &log_file_)
+        : rank(rank_), log_to_file(log_to_file_), log_file(log_file_) {
       ceph_assert(rank_ != MDS_RANK_NONE);
+      if (log_to_file) {
+        open_damage_log_file(fout, log_file);
+      }
     }
 
     /**
@@ -156,6 +169,9 @@ class DamageTable
      */
     bool notify_remote_damaged(inodeno_t ino, std::string_view path);
 
+    bool notify_remote_link_damaged(inodeno_t ino, const std::string &path,
+                                    const std::string &head_path = "");
+
     void remove_dentry_damage_entry(CDir *dir);
 
     void remove_dirfrag_damage_entry(CDir *dir);
@@ -171,9 +187,35 @@ class DamageTable
 
     bool is_remote_damaged(const inodeno_t ino) const;
 
+    bool is_remote_link_damaged(const inodeno_t ino) const;
+
     void dump(Formatter *f) const;
 
     void erase(damage_entry_id_t damage_id);
+
+    void set_log_to_file(bool _log_to_file) {
+      log_to_file = _log_to_file;
+      if (log_to_file) {
+        open_damage_log_file(fout, log_file);
+      } else {
+        close_damage_log_file();
+      }
+    }
+
+    void set_log_file(const std::string &_log_file) {
+      log_file = _log_file;
+      if (log_to_file) {
+        open_damage_log_file(fout, log_file);
+      }
+    }
+
+    void clear();
+
+  private:
+    void open_damage_log_file(std::ofstream &fout,
+                              const std::filesystem::path &file_path);
+    void close_damage_log_file();
+    std::ofstream fout;
 
   protected:
     // I need to know my MDS rank so that I can check if
@@ -194,10 +236,17 @@ class DamageTable
     // (i.e. have probably/possibly missing backtraces)
     std::map<inodeno_t, DamageEntryRef> remotes;
 
+    // Map of all links which could not be resolved
+    // (i.e. have probably/possibly missing primary inodes)
+    std::map<inodeno_t, std::map<std::string, DamageEntryRef>> remote_links;
+
     // All damage, by ID.  This is a secondary index
     // to the dirfrag, dentry, remote maps.  It exists
     // to enable external tools to unambiguously operate
     // on particular entries.
     std::map<damage_entry_id_t, DamageEntryRef> by_id;
+    bool log_to_file = false;
+    std::string log_file = "";
+    bool log_file_opened = false;
 };
 #endif // DAMAGE_TABLE_H_

--- a/src/mds/DamageTable.h
+++ b/src/mds/DamageTable.h
@@ -169,7 +169,8 @@ class DamageTable
      */
     bool notify_remote_damaged(inodeno_t ino, std::string_view path);
 
-    bool notify_remote_link_damaged(inodeno_t ino, const std::string &path,
+    bool notify_remote_link_damaged(inodeno_t ino, inodeno_t parent_ino,
+                                    const std::string &path,
                                     const std::string &head_path = "");
 
     void remove_dentry_damage_entry(CDir *dir);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8497,8 +8497,8 @@ int MDCache::path_traverse(MDRequestRef& mdr, MDSContextFactory& cf,
             dn->get_dir()->get_inode()->make_path_string(path);
             path += "/";
             path += dn->get_name();
-            mds->damage_table.notify_remote_link_damaged(dnl->get_remote_ino(),
-                                                         path);
+            mds->damage_table.notify_remote_link_damaged(
+                dnl->get_remote_ino(), dn->get_dir()->get_inode()->ino(), path);
             return -CEPHFS_EIO;
           }
           open_remote_dentry(dn, true, cf.build(),
@@ -8817,13 +8817,16 @@ void MDCache::_open_remote_dentry_finish(CDentry *dn, inodeno_t ino, MDSContext 
 
       std::string path;
       CDir *dir = dn->get_dir();
+      inodeno_t parent_ino;
       if (dir) {
 	dir->get_inode()->make_path_string(path);
 	path += "/";
         path += dn->get_name();
+        parent_ino = dir->get_inode()->ino();
       }
 
-      bool fatal = mds->damage_table.notify_remote_link_damaged(ino, path);
+      bool fatal =
+          mds->damage_table.notify_remote_link_damaged(ino, parent_ino, path);
       if (fatal) {
 	mds->damaged();
 	ceph_abort();  // unreachable, damaged() respawns us

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -402,6 +402,9 @@ void MDSDaemon::set_up_admin_socket()
 				     asok_hook,
 				     "Remove a damage table entry");
   ceph_assert(r == 0);
+  r = admin_socket->register_command("damage clear", asok_hook,
+                                     "clear the damage list");
+  ceph_assert(r == 0);
   r = admin_socket->register_command("osdmap barrier name=target_epoch,type=CephInt",
 				     asok_hook,
 				     "Wait until the MDS has this OSD map epoch");

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -498,7 +498,9 @@ MDSRank::MDSRank(
     cct(msgr->cct), mds_lock(mds_lock_), clog(clog_),
     timer(timer_), mdsmap(mdsmap_),
     objecter(new Objecter(g_ceph_context, msgr, monc_, ioc)),
-    damage_table(whoami_), sessionmap(this),
+    damage_table(whoami_, g_conf()->mds_damage_log_to_file,
+                   g_conf()->mds_damage_log_file),
+    sessionmap(this),
     op_tracker(g_ceph_context, g_conf()->mds_enable_op_tracker,
                g_conf()->osd_num_op_tracker_shard),
     progress_thread(this), whoami(whoami_),
@@ -2929,6 +2931,9 @@ void MDSRankDispatcher::handle_asok_command(
       goto out;
     }
     damage_table.erase(id);
+  } else if (command == "damage clear") {
+    std::lock_guard l(mds_lock);
+    damage_table.clear();
   } else {
     r = -CEPHFS_ENOSYS;
   }
@@ -3866,6 +3871,8 @@ const char** MDSRankDispatcher::get_tracked_conf_keys() const
     "mds_inject_rename_corrupt_dentry_first",
     "mds_inject_journal_corrupt_dentry_first",
     "mds_session_metadata_threshold",
+    "mds_damage_log_to_file",
+    "mds_damage_log_file",
     NULL
   };
   return KEYS;
@@ -3935,6 +3942,14 @@ void MDSRankDispatcher::handle_conf_change(const ConfigProxy& conf, const std::s
   }
   if (changed.count("mds_inject_journal_corrupt_dentry_first")) {
     inject_journal_corrupt_dentry_first = g_conf().get_val<double>("mds_inject_journal_corrupt_dentry_first");
+  }
+  if (changed.count("mds_damage_log_to_file")) {
+    damage_table.set_log_to_file(
+        g_conf().get_val<bool>("mds_damage_log_to_file"));
+  }
+  if (changed.count("mds_damage_log_file")) {
+    damage_table.set_log_file(
+        g_conf().get_val<std::string>("mds_damage_log_file"));
   }
 
   finisher->queue(new LambdaContext([this, changed](int) {

--- a/src/mds/ScrubHeader.h
+++ b/src/mds/ScrubHeader.h
@@ -64,6 +64,18 @@ public:
   }
   unsigned get_num_pending() const { return num_pending; }
 
+  void inc_scrubbed_inode_count() { ++scrubbed_inode_count; }
+
+  uint64_t get_scrubbed_inode_count() const { return scrubbed_inode_count; }
+
+  void inc_scrubbed_remote_link_count(uint64_t val = 1) {
+    scrubbed_remote_link_count += val;
+  }
+
+  uint64_t get_scrubbed_remote_link_count() const {
+    return scrubbed_remote_link_count;
+  }
+
 protected:
   const std::string tag;
   bool is_tag_internal;
@@ -76,6 +88,8 @@ protected:
   bool repaired = false;  // May be set during scrub if repairs happened
   unsigned epoch_last_forwarded = 0;
   unsigned num_pending = 0;
+  uint64_t scrubbed_inode_count = 0;
+  uint64_t scrubbed_remote_link_count = 0;
 };
 
 typedef std::shared_ptr<ScrubHeader> ScrubHeaderRef;

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -341,7 +341,7 @@ void ScrubStack::scrub_dir_inode(CInode *in, bool *added_children, bool *done)
       dir->add_waiter(CDir::WAIT_UNFREEZE, gather.new_sub());
     } else if (dir->get_version() == 0) {
       dout(20) << __func__ << " barebones " << *dir  << dendl;
-      dir->fetch_keys({}, gather.new_sub());
+      dir->fetch_keys({}, gather.new_sub(), true);
     } else {
       _enqueue(dir, header, true);
       queued.insert_raw(dir->get_frag());

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -59,12 +59,18 @@ void ScrubStack::dequeue(MDSCacheObject *obj)
   stack_size--;
 }
 
-int ScrubStack::_enqueue(MDSCacheObject *obj, ScrubHeaderRef& header, bool top)
-{
+int ScrubStack::_enqueue(
+    MDSCacheObject *obj, ScrubHeaderRef &header, bool top, bool *added,
+    std::vector<std::pair<std::string, inodeno_t>> &&remote_links) {
   ceph_assert(ceph_mutex_is_locked_by_me(mdcache->mds->mds_lock));
   if (CInode *in = dynamic_cast<CInode*>(obj)) {
     if (in->scrub_is_in_progress()) {
       dout(10) << __func__ << " with {" << *in << "}" << ", already in scrubbing" << dendl;
+      if (!remote_links.empty()) {
+        in->scrub_add_remote_link(std::move(remote_links));
+      } else {
+        in->set_forward_scrub(true);
+      }
       return -CEPHFS_EBUSY;
     }
     if(in->state_test(CInode::STATE_PURGING)) {
@@ -75,6 +81,11 @@ int ScrubStack::_enqueue(MDSCacheObject *obj, ScrubHeaderRef& header, bool top)
 
     dout(10) << __func__ << " with {" << *in << "}" << ", top=" << top << dendl;
     in->scrub_initialize(header);
+    if (!remote_links.empty()) {
+      in->scrub_add_remote_link(std::move(remote_links));
+      in->set_forward_scrub(false);
+    }
+
   } else if (CDir *dir = dynamic_cast<CDir*>(obj)) {
     if (dir->scrub_is_in_progress()) {
       dout(10) << __func__ << " with {" << *dir << "}" << ", already in scrubbing" << dendl;
@@ -103,7 +114,12 @@ int ScrubStack::_enqueue(MDSCacheObject *obj, ScrubHeaderRef& header, bool top)
     scrub_stack.push_front(&obj->item_scrub);
   else
     scrub_stack.push_back(&obj->item_scrub);
-  return 1;
+
+  if (added) {
+    *added = true;
+  }
+
+  return 0;
 }
 
 int ScrubStack::enqueue(CInode *in, ScrubHeaderRef& header, bool top)
@@ -209,39 +225,43 @@ void ScrubStack::kick_off_scrubs()
       if (scrubs_in_progress == 0) {
         set_state(STATE_IDLE);
       }
-
       return;
     }
 
     assert(state == STATE_RUNNING || state == STATE_IDLE);
     set_state(STATE_RUNNING);
 
-    if (CInode *in = dynamic_cast<CInode*>(*it)) {
+    if (CInode *in = dynamic_cast<CInode *>(*it)) {
       dout(20) << __func__ << " examining " << *in << dendl;
       ++it;
 
       if (!validate_inode_auth(in))
-	continue;
+        continue;
 
       if (!in->is_dir()) {
-	// it's a regular file, symlink, or hard link
-	dequeue(in); // we only touch it this once, so remove from stack
-
-	scrub_file_inode(in);
+        // it's a regular file, symlink, or hard link
+        dequeue(in); // we only touch it this once, so remove from stack
+        scrub_file_inode(in);
+      } else if (in->scrub_info()->forward_scrub) {
+        bool added_children = false;
+        bool done = false; // it's done, so pop it off the stack
+        scrub_dir_inode(in, &added_children, &done);
+        if (done) {
+          dout(20) << __func__ << " dir inode, done" << dendl;
+          in->set_forward_scrub(false);
+          dequeue(in);
+        }
+        if (added_children) {
+          // dirfrags were queued at top of stack
+          it = scrub_stack.begin();
+        }
+      } else if (!in->scrub_info()->remote_links.empty()){
+        dequeue(in);
+        scrub_dir_inode_final(in);
       } else {
-	bool added_children = false;
-	bool done = false; // it's done, so pop it off the stack
-	scrub_dir_inode(in, &added_children, &done);
-	if (done) {
-	  dout(20) << __func__ << " dir inode, done" << dendl;
-	  dequeue(in);
-	}
-	if (added_children) {
-	  // dirfrags were queued at top of stack
-	  it = scrub_stack.begin();
-	}
+        dequeue(in);
       }
-    } else if (CDir *dir = dynamic_cast<CDir*>(*it)) {
+    } else if (CDir *dir = dynamic_cast<CDir *>(*it)) {
       ++it;
       bool added_children = false;
       bool done = false; // it's done, so pop it off the stack
@@ -392,9 +412,10 @@ public:
   ScrubStack *stack;
   CInode::validated_data result;
   CInode *target;
+  MDCache* mdcache;
 
   C_InodeValidated(MDSRank *mds, ScrubStack *stack_, CInode *target_)
-    : MDSInternalContext(mds), stack(stack_), target(target_)
+    : MDSInternalContext(mds), stack(stack_), target(target_), mdcache(mds->mdcache)
   {
     stack->scrubs_in_progress++;
   }
@@ -408,10 +429,107 @@ public:
 void ScrubStack::scrub_dir_inode_final(CInode *in)
 {
   dout(20) << __func__ << " " << *in << dendl;
+  ScrubHeaderRef header = in->scrub_info()->header;
+  if (!in->scrub_info()->forward_scrub &&
+      !in->scrub_info()->remote_links.empty()) {
+    auto parent = in->get_projected_parent_dn();
+    if (mdcache->mds->damage_table.is_remote_damaged(in->ino()) ||
+        (parent && mdcache->mds->damage_table.is_dentry_damaged(
+                       parent->get_dir(), parent->get_name(), parent->last))) {
+      for (auto &[remote_link_path, remote_ino] :
+           in->scrub_info()->remote_links) {
+        add_remote_link_damage(remote_link_path, remote_ino, header);
+      }
+      in->scrub_finished();
+      return;
+    }
+  }
 
   C_InodeValidated *fin = new C_InodeValidated(mdcache->mds, this, in);
   in->validate_disk_state(&fin->result, fin);
   return;
+}
+
+void ScrubStack::add_remote_link_damage(const std::string &path, inodeno_t ino,
+                                        ScrubHeaderRef &header) {
+  CInode* remote_inode = mdcache->get_inode(ino);
+  std::string head_path = "";
+  if (remote_inode) {
+    remote_inode->make_path_string(head_path);
+  }
+  mdcache->mds->damage_table.notify_remote_link_damaged(ino, path, head_path);
+  header->inc_scrubbed_remote_link_count();
+}
+
+class C_RemoteInodeOpened : public MDSInternalContext {
+public:
+  ScrubStack *stack;
+  CDentry *dn;
+  ScrubHeaderRef header;
+  inodeno_t ino;
+  MDCache* mdcache;
+  C_RemoteInodeOpened(MDSRank *mds, ScrubStack *stack_,
+                       ScrubHeaderRef &header_, CDentry *dn_, inodeno_t ino_)
+      : MDSInternalContext(mds), stack(stack_), header(header_), dn(dn_),
+        ino(ino_), mdcache(stack_->mdcache) {
+    stack->scrubs_in_progress++;
+    header->inc_num_pending();
+    dn->get(MDSCacheObject::PIN_SCRUBQUEUE);
+  }
+  void finish(int r) override {
+    std::string path;
+    CDir *dir = dn->get_dir();
+    CInode *remote_inode = nullptr;
+
+    stack->scrubs_in_progress--;
+    CDentry::linkage_t *dnl = dn->get_projected_linkage();
+    if (r < 0 || !(dnl->is_remote() && dnl->get_remote_ino() == ino)) {
+      goto safe_exit;
+    }
+    remote_inode = mds->mdcache->get_inode(dnl->get_remote_ino());
+    if (!remote_inode) {
+      std::string path;
+      if (dir) {
+        dir->get_inode()->make_path_string(path);
+        path += "/";
+        path += dn->get_name();
+      }
+      stack->add_remote_link_damage(path, ino, header);
+      goto safe_exit;
+    }
+    stack->_enqueue(remote_inode, header, true, nullptr,
+                    {std::make_pair(std::move(path), ino)});
+    stack->kick_off_scrubs();
+  safe_exit:
+    dn->put(MDSCacheObject::PIN_SCRUBQUEUE);
+    header->dec_num_pending();
+  }
+};
+
+CInode *ScrubStack::remote_link_checkup(CDentry *dn, ScrubHeaderRef &header) {
+
+  CDentry::linkage_t *dnl = dn->get_linkage();
+  CInode *remote_inode = mdcache->get_inode(dnl->get_remote_ino());
+  if (!remote_inode) {
+    if (mdcache->mds->damage_table.is_remote_damaged(dnl->get_remote_ino())) {
+      dout(4) << "scrub: remote dentry points to damaged ino " << *dn << dendl;
+      std::string path;
+      dn->get_dir()->get_inode()->make_path_string(path);
+      path += "/";
+      path += dn->get_name();
+      mdcache->mds->damage_table.notify_remote_link_damaged(
+          dnl->get_remote_ino(), path);
+      return nullptr;
+    }
+    MDSContext *ctx =
+        (!header->get_repair() && g_conf()->mds_force_hard_link_scrubbing)
+            ? (MDSContext *)(new C_RemoteInodeOpened(
+                  mdcache->mds, this, header, dn, dnl->get_remote_ino()))
+            : (MDSContext *)(new C_MDSInternalNoop());
+
+    mdcache->open_remote_dentry(dn, true, ctx);
+  }
+  return remote_inode;
 }
 
 void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
@@ -454,11 +572,19 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
 	continue;
       }
       if (dnl->is_primary()) {
-        if (_enqueue(dnl->get_inode(), header, true) == 1) {
-          *added_children = true;
-        }
+        _enqueue(dnl->get_inode(), header, true, added_children);
       } else if (dnl->is_remote()) {
-	// TODO: check remote linkage
+        auto remote_ino = dnl->get_remote_ino();
+        CInode *remote_inode = remote_link_checkup(dn, header);
+        if (remote_inode && !header->get_repair() &&
+            g_conf()->mds_force_hard_link_scrubbing) {
+          std::string remote_path;
+          dir->get_inode()->make_path_string(remote_path);
+          remote_path += "/";
+          remote_path += dn->get_name();
+          _enqueue(remote_inode, header, true, added_children,
+                   {std::make_pair(std::move(remote_path), remote_ino)});
+        }
       }
     }
   }
@@ -477,8 +603,25 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
   *done = true;
   dout(10) << __func__ << " done" << dendl;
 }
+
 void ScrubStack::scrub_file_inode(CInode *in)
 {
+  ScrubHeaderRef header = in->scrub_info()->header;
+  if (!in->scrub_info()->forward_scrub &&
+      !in->scrub_info()->remote_links.empty()) {
+    auto parent = in->get_projected_parent_dn();
+    if (mdcache->mds->damage_table.is_remote_damaged(in->ino()) ||
+        (parent && mdcache->mds->damage_table.is_dentry_damaged(
+                       parent->get_dir(), parent->get_name(), parent->last))) {
+      for (auto &[remote_link_path, remote_ino] :
+           in->scrub_info()->remote_links) {
+        add_remote_link_damage(remote_link_path, remote_ino, header);
+      }
+      in->scrub_finished();
+      return;
+    }
+  }
+
   C_InodeValidated *fin = new C_InodeValidated(mdcache->mds, this, in);
   // At this stage the DN is already past scrub_initialize, so
   // it's in the cache, it has PIN_SCRUBQUEUE and it is authpinned
@@ -489,7 +632,7 @@ void ScrubStack::_validate_inode_done(CInode *in, int r,
 				      const CInode::validated_data &result)
 {
   LogChannelRef clog = mdcache->mds->clog;
-  const ScrubHeaderRefConst header = in->scrub_info()->header;
+  ScrubHeaderRef header = in->scrub_info()->header;
 
   std::string path;
   if (!result.passed_validation) {
@@ -537,7 +680,34 @@ void ScrubStack::_validate_inode_done(CInode *in, int r,
     dout(10) << __func__ << " scrub passed on inode " << *in << dendl;
   }
 
-  in->scrub_finished();
+  if (!in->scrub_info()->remote_links.empty()) {
+    if (!result.passed_validation) {
+      for (auto &[remote_link_path, remote_ino] :
+           in->scrub_info()->remote_links) {
+        add_remote_link_damage(remote_link_path, remote_ino, header);
+      }
+    } else {
+      CDentry *pdn = in->get_parent_dn();
+      if (pdn) {
+        CInode *diri = pdn->get_dir()->get_inode();
+        _enqueue(diri, header, true, nullptr,
+                 std::move(in->scrub_move_remote_links()));
+      } else {
+        header->inc_scrubbed_remote_link_count(
+            in->scrub_info()->remote_links.size());
+      }
+    }
+  }
+  in->scrub_reset_remote_links();
+
+  if (in->scrub_info()->forward_scrub && in->is_dir()) {
+    in->scrub_finished();
+    _enqueue(in, header, true);
+  } else {
+    in->scrub_finished();
+  }
+
+  header->inc_scrubbed_inode_count();
 }
 
 void ScrubStack::complete_control_contexts(int r) {
@@ -637,7 +807,8 @@ void ScrubStack::scrub_status(Formatter *f) {
     if (scrubbing_map.empty())
       *css << "no active scrubs running";
     else
-      *css << state << " (waiting for more scrubs)";
+      *css << state << " (waiting for more scrubs, " << stack_size
+           << "inodes in the stack)";
   } else if (state == STATE_RUNNING) {
     if (clear_stack) {
       *css << "ABORTING";
@@ -676,6 +847,10 @@ void ScrubStack::scrub_status(Formatter *f) {
       f->dump_stream("path") << "#" << header->get_origin();
 
     f->dump_string("tag", header->get_tag());
+    f->dump_unsigned("scrubbed_inode_count",
+                     header->get_scrubbed_inode_count());
+    f->dump_unsigned("scrubbed_remote_link_count",
+                     header->get_scrubbed_remote_link_count());
 
     CachedStackStringStream optcss;
     if (header->get_recursive()) {

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -61,16 +61,11 @@ void ScrubStack::dequeue(MDSCacheObject *obj)
 
 int ScrubStack::_enqueue(
     MDSCacheObject *obj, ScrubHeaderRef &header, bool top, bool *added,
-    std::vector<std::pair<std::string, inodeno_t>> &&remote_links) {
+    std::vector<CInode::remote_link_info_t> &&remote_links) {
   ceph_assert(ceph_mutex_is_locked_by_me(mdcache->mds->mds_lock));
   if (CInode *in = dynamic_cast<CInode*>(obj)) {
-    if (in->scrub_is_in_progress()) {
+    if (in->maybe_update_scrub_in_progress(std::move(remote_links))) {
       dout(10) << __func__ << " with {" << *in << "}" << ", already in scrubbing" << dendl;
-      if (!remote_links.empty()) {
-        in->scrub_add_remote_link(std::move(remote_links));
-      } else {
-        in->set_forward_scrub(true);
-      }
       return -CEPHFS_EBUSY;
     }
     if(in->state_test(CInode::STATE_PURGING)) {
@@ -78,14 +73,8 @@ int ScrubStack::_enqueue(
       // treating this as success since purge will make sure this inode goes away
       return 0;
     }
-
     dout(10) << __func__ << " with {" << *in << "}" << ", top=" << top << dendl;
-    in->scrub_initialize(header);
-    if (!remote_links.empty()) {
-      in->scrub_add_remote_link(std::move(remote_links));
-      in->set_forward_scrub(false);
-    }
-
+    in->scrub_initialize(header, std::move(remote_links));
   } else if (CDir *dir = dynamic_cast<CDir*>(obj)) {
     if (dir->scrub_is_in_progress()) {
       dout(10) << __func__ << " with {" << *dir << "}" << ", already in scrubbing" << dendl;
@@ -242,32 +231,24 @@ void ScrubStack::kick_off_scrubs()
         // it's a regular file, symlink, or hard link
         dequeue(in); // we only touch it this once, so remove from stack
         scrub_file_inode(in);
-      } else if (in->scrub_info()->forward_scrub) {
-        bool added_children = false;
-        bool done = false; // it's done, so pop it off the stack
-        scrub_dir_inode(in, &added_children, &done);
-        if (done) {
-          dout(20) << __func__ << " dir inode, done" << dendl;
-          in->set_forward_scrub(false);
-          dequeue(in);
-        }
-        if (added_children) {
-          // dirfrags were queued at top of stack
-          it = scrub_stack.begin();
-        }
-      } else if (!in->scrub_info()->remote_links.empty()){
-        dequeue(in);
-        scrub_dir_inode_final(in);
       } else {
-        dequeue(in);
+	bool added_children = false;
+	bool done = scrub_dir_inode(in, &added_children);
+	if (done) {
+	  dout(20) << __func__ << " dir inode, done" << dendl;
+	  dequeue(in);
+	}
+	if (added_children) {
+	  // dirfrags were queued at top of stack
+	  it = scrub_stack.begin();
+	}
       }
     } else if (CDir *dir = dynamic_cast<CDir *>(*it)) {
       ++it;
       bool added_children = false;
-      bool done = false; // it's done, so pop it off the stack
-      scrub_dirfrag(dir, &added_children, &done);
-      if (done) {
-        dout(20) << __func__ << " dirfrag, done" << dendl;
+      if (scrub_dirfrag(dir, &added_children)) {
+	// it's done, so pop it off the stack
+	dout(20) << __func__ << " dirfrag, done" << dendl;
         dequeue(dir);
       }
       if (added_children) {
@@ -324,9 +305,8 @@ bool ScrubStack::validate_inode_auth(CInode *in)
   }
 }
 
-void ScrubStack::scrub_dir_inode(CInode *in, bool *added_children, bool *done)
+bool ScrubStack::scrub_dir_inode_forward(CInode* in, bool* added_children)
 {
-  dout(10) << __func__ << " " << *in << dendl;
   ceph_assert(in->is_auth());
   MDSRank *mds = mdcache->mds;
 
@@ -347,7 +327,7 @@ void ScrubStack::scrub_dir_inode(CInode *in, bool *added_children, bool *done)
     CDir *dir = in->get_or_open_dirfrag(mdcache, fg);
     if (!dir->is_auth()) {
       if (dir->is_ambiguous_auth()) {
-	dout(20) << __func__ << " ambiguous auth " << *dir  << dendl;
+	dout(20) << __func__ << " ambiguous auth " << *dir << dendl;
 	dir->add_waiter(MDSCacheObject::WAIT_SINGLEAUTH, gather.new_sub());
       } else if (mds->is_cluster_degraded()) {
 	dout(20) << __func__ << " cluster degraded" << dendl;
@@ -357,10 +337,10 @@ void ScrubStack::scrub_dir_inode(CInode *in, bool *added_children, bool *done)
 	scrub_remote[auth].insert_raw(fg);
       }
     } else if (!dir->can_auth_pin()) {
-      dout(20) << __func__ << " freezing/frozen " << *dir  << dendl;
+      dout(20) << __func__ << " freezing/frozen " << *dir << dendl;
       dir->add_waiter(CDir::WAIT_UNFREEZE, gather.new_sub());
     } else if (dir->get_version() == 0) {
-      dout(20) << __func__ << " barebones " << *dir  << dendl;
+      dout(20) << __func__ << " barebones " << *dir << dendl;
       dir->fetch_keys({}, gather.new_sub(), true);
     } else {
       _enqueue(dir, header, true);
@@ -374,7 +354,7 @@ void ScrubStack::scrub_dir_inode(CInode *in, bool *added_children, bool *done)
   if (gather.has_subs()) {
     gather.set_finisher(new C_RetryScrub(this, in));
     gather.activate();
-    return;
+    return false;
   }
 
   if (!scrub_remote.empty()) {
@@ -386,7 +366,7 @@ void ScrubStack::scrub_dir_inode(CInode *in, bool *added_children, bool *done)
     scrub_r.tag = header->get_tag();
 
     for (auto& p : scrub_remote) {
-      dout(20) << __func__ << " forward " << p.second  << " to mds." << p.first << dendl;
+      dout(20) << __func__ << " forward " << p.second << " to mds." << p.first << dendl;
       auto r = make_message<MMDSScrub>(MMDSScrub::OP_QUEUEDIR, in->ino(),
 				       std::move(p.second), header->get_tag(),
 				       header->get_origin(), header->is_internal_tag(),
@@ -397,142 +377,245 @@ void ScrubStack::scrub_dir_inode(CInode *in, bool *added_children, bool *done)
     }
     // wait for ACKs
     add_to_waiting(in);
-    return;
+    return false;
   }
-
-  scrub_dir_inode_final(in);
-
-  *done = true;
-  dout(10) << __func__ << " done" << dendl;
+  return true;
 }
 
-class C_InodeValidated : public MDSInternalContext
+bool ScrubStack::scrub_dir_inode(CInode* in, bool* added_children)
 {
-public:
-  ScrubStack *stack;
-  CInode::validated_data result;
-  CInode *target;
-  MDCache* mdcache;
-
-  C_InodeValidated(MDSRank *mds, ScrubStack *stack_, CInode *target_)
-    : MDSInternalContext(mds), stack(stack_), target(target_), mdcache(mds->mdcache)
-  {
-    stack->scrubs_in_progress++;
+  dout(10) << __func__ << " " << *in << dendl;
+  if (in->scrub_info()->forward_scrub && !scrub_dir_inode_forward(in, added_children)) {
+    return false;
   }
-  void finish(int r) override {
-    stack->_validate_inode_done(target, r, result);
-    stack->scrubs_in_progress--;
-    stack->kick_off_scrubs();
-  }
-};
+  in->reset_forward_scrub(); //we've just completed forward scrub, let's reset the flag
+  scrub_inode_validate(in);
+  return true; // if we get here we're done unconditionally
+}
 
-void ScrubStack::scrub_dir_inode_final(CInode *in)
+void ScrubStack::scrub_file_inode(CInode* in)
 {
-  dout(20) << __func__ << " " << *in << dendl;
-  ScrubHeaderRef header = in->scrub_info()->header;
-  if (!in->scrub_info()->forward_scrub &&
-      !in->scrub_info()->remote_links.empty()) {
+  dout(10) << __func__ << " " << *in << dendl;
+  scrub_inode_validate(in);
+}
+
+void ScrubStack::scrub_inode_validate(CInode *in)
+{
+  if (!in->scrub_info()->remote_links.empty()) {
     auto parent = in->get_projected_parent_dn();
     if (mdcache->mds->damage_table.is_remote_damaged(in->ino()) ||
         (parent && mdcache->mds->damage_table.is_dentry_damaged(
                        parent->get_dir(), parent->get_name(), parent->last))) {
-      for (auto &[remote_link_path, remote_ino] :
-           in->scrub_info()->remote_links) {
-        add_remote_link_damage(remote_link_path, remote_ino, header);
+      ScrubHeaderRef header = in->scrub_info()->header;
+      for (auto &p : in->scrub_info()->remote_links) {
+        add_remote_link_damage(p.path, p.ino, p.parent_ino, header);
       }
+      dout(20) << __func__ << " damaged " << *in << dendl;
       in->scrub_finished();
       return;
     }
   }
 
+  class C_InodeValidated : public MDSInternalContext
+  {
+  public:
+    ScrubStack* stack;
+    CInode::validated_data result;
+    CInode* target;
+
+    C_InodeValidated(MDSRank* mds, ScrubStack* stack_, CInode* target_)
+      : MDSInternalContext(mds), stack(stack_), target(target_)
+    {
+      stack->scrubs_in_progress++;
+    }
+    void finish(int r) override {
+      stack->scrubs_in_progress--;
+      stack->_validate_inode_done(target, r, result);
+    }
+  };
   C_InodeValidated *fin = new C_InodeValidated(mdcache->mds, this, in);
   in->validate_disk_state(&fin->result, fin);
   return;
 }
 
+void ScrubStack::_validate_inode_done(CInode* in, int r,
+  const CInode::validated_data& result)
+{
+  LogChannelRef clog = mdcache->mds->clog;
+  ScrubHeaderRef header = in->scrub_info()->header;
+
+  std::string path;
+  if (!result.passed_validation) {
+    // Build path string for use in messages
+    in->make_path_string(path, true);
+  }
+
+  if (result.backtrace.checked && !result.backtrace.passed &&
+    !result.backtrace.repaired)
+  {
+    // Record backtrace fails as remote linkage damage, as
+    // we may not be able to resolve hard links to this inode
+    mdcache->mds->damage_table.notify_remote_damaged(in->ino(), path);
+  } else if (result.inode.checked && !result.inode.passed &&
+    !result.inode.repaired) {
+    // Record damaged inode structures as damaged dentries as
+    // that is where they are stored
+    auto parent = in->get_projected_parent_dn();
+    if (parent) {
+      auto dir = parent->get_dir();
+      mdcache->mds->damage_table.notify_dentry(
+	dir->inode->ino(), dir->frag, parent->last, parent->get_name(), path);
+    }
+  }
+
+  // Inform the cluster log if we found an error
+  if (!result.passed_validation) {
+    if (result.all_damage_repaired()) {
+      clog->info() << "Scrub repaired inode " << in->ino()
+	<< " (" << path << ")";
+    } else {
+      clog->warn() << "Scrub error on inode " << in->ino()
+	<< " (" << path << ") see " << g_conf()->name
+	<< " log and `damage ls` output for details";
+    }
+
+    // Put the verbose JSON output into the MDS log for later inspection
+    JSONFormatter f;
+    result.dump(&f);
+    CachedStackStringStream css;
+    f.flush(*css);
+    derr << __func__ << " scrub error on inode " << *in << ": " << css->strv()
+      << dendl;
+  } else {
+    dout(10) << __func__ << " scrub passed on inode " << *in << dendl;
+  }
+
+  if (!in->scrub_info()->remote_links.empty()) {
+    if (!result.passed_validation) {
+      for (auto &p : in->scrub_info()->remote_links) {
+        add_remote_link_damage(p.path, p.ino, p.parent_ino, header);
+      }
+    } else {
+      CDentry *pdn = in->get_parent_dn();
+      if (pdn) {
+        CInode *diri = pdn->get_dir()->get_inode();
+        _enqueue(diri, header, true, nullptr,
+                 std::move(in->scrub_move_remote_links()));
+      } else {
+        header->inc_scrubbed_remote_link_count(
+            in->scrub_info()->remote_links.size());
+      }
+    }
+  }
+  // re-run forward scrub if we've got such a request while validating
+  bool retry = in->scrub_info()->forward_scrub && in->is_dir();
+  in->scrub_finished();
+  if (retry) {
+    // scrub_finished above should keep forward_scrub set.
+    ceph_assert(in->scrub_info()->forward_scrub);
+    _enqueue(in, header, true);
+  }
+
+  header->inc_scrubbed_inode_count();
+  kick_off_scrubs();
+}
+
 void ScrubStack::add_remote_link_damage(const std::string &path, inodeno_t ino,
+                                        inodeno_t parent_ino,
                                         ScrubHeaderRef &header) {
-  CInode* remote_inode = mdcache->get_inode(ino);
   std::string head_path = "";
+  CInode* remote_inode = mdcache->get_inode(ino);
   if (remote_inode) {
     remote_inode->make_path_string(head_path);
   }
-  mdcache->mds->damage_table.notify_remote_link_damaged(ino, path, head_path);
+  add_remote_link_damage(path, head_path, ino, parent_ino, header);
+}
+
+void ScrubStack::add_remote_link_damage(const std::string &path,
+                                        const std::string &head_path,
+                                        inodeno_t ino, inodeno_t parent_ino,
+                                        ScrubHeaderRef &header) {
+  mdcache->mds->damage_table.notify_remote_link_damaged(ino, parent_ino, path,
+                                                        head_path);
   header->inc_scrubbed_remote_link_count();
 }
 
-class C_RemoteInodeOpened : public MDSInternalContext {
-public:
-  ScrubStack *stack;
-  CDentry *dn;
-  ScrubHeaderRef header;
-  inodeno_t ino;
-  MDCache* mdcache;
-  C_RemoteInodeOpened(MDSRank *mds, ScrubStack *stack_,
-                       ScrubHeaderRef &header_, CDentry *dn_, inodeno_t ino_)
-      : MDSInternalContext(mds), stack(stack_), header(header_), dn(dn_),
-        ino(ino_), mdcache(stack_->mdcache) {
-    stack->scrubs_in_progress++;
-    header->inc_num_pending();
-    dn->get(MDSCacheObject::PIN_SCRUBQUEUE);
-  }
-  void finish(int r) override {
-    std::string path;
-    CDir *dir = dn->get_dir();
-    CInode *remote_inode = nullptr;
-
-    stack->scrubs_in_progress--;
-    CDentry::linkage_t *dnl = dn->get_projected_linkage();
-    if (r < 0 || !(dnl->is_remote() && dnl->get_remote_ino() == ino)) {
-      goto safe_exit;
+void ScrubStack::remote_link_checkup(CDentry *dn, ScrubHeaderRef &header, bool *added)
+{
+  class C_RemoteInodeOpened : public MDSInternalContext {
+  public:
+    ScrubStack* stack;
+    ScrubHeaderRef header;
+    CDentry* dn;
+    inodeno_t ino;
+    C_RemoteInodeOpened(ScrubStack* stack_,
+      ScrubHeaderRef& header_, CDentry* dn_, inodeno_t ino_)
+      : MDSInternalContext(stack_->mdcache->mds), stack(stack_), header(header_), dn(dn_) {
+      header->inc_num_pending();
+      dn->get(MDSCacheObject::PIN_SCRUBQUEUE);
+      stack->scrubs_in_progress++;
     }
-    remote_inode = mds->mdcache->get_inode(dnl->get_remote_ino());
-    if (!remote_inode) {
-      std::string path;
-      if (dir) {
-        dir->get_inode()->make_path_string(path);
-        path += "/";
-        path += dn->get_name();
-      }
-      stack->add_remote_link_damage(path, ino, header);
-      goto safe_exit;
+    void finish(int r) override {
+      stack->scrubs_in_progress--;
+      stack->_validate_remote_inode_opened(r, header, dn);
     }
-    stack->_enqueue(remote_inode, header, true, nullptr,
-                    {std::make_pair(std::move(path), ino)});
-    stack->kick_off_scrubs();
-  safe_exit:
-    dn->put(MDSCacheObject::PIN_SCRUBQUEUE);
-    header->dec_num_pending();
-  }
-};
+    ~C_RemoteInodeOpened() override {
+      dn->put(MDSCacheObject::PIN_SCRUBQUEUE);
+      header->dec_num_pending();
+    }
+  };
 
-CInode *ScrubStack::remote_link_checkup(CDentry *dn, ScrubHeaderRef &header) {
-
-  CDentry::linkage_t *dnl = dn->get_linkage();
-  CInode *remote_inode = mdcache->get_inode(dnl->get_remote_ino());
+  ceph_assert(dn->get_linkage());
+  auto remote_ino = dn->get_linkage()->get_remote_ino();
+  CInode *remote_inode = mdcache->get_inode(remote_ino);
+  bool do_hardlink_scrub = !header->get_repair() && g_conf()->mds_force_hard_link_scrubbing;
   if (!remote_inode) {
-    if (mdcache->mds->damage_table.is_remote_damaged(dnl->get_remote_ino())) {
+    if (mdcache->mds->damage_table.is_remote_damaged(remote_ino)) {
       dout(4) << "scrub: remote dentry points to damaged ino " << *dn << dendl;
-      std::string path;
-      dn->get_dir()->get_inode()->make_path_string(path);
-      path += "/";
-      path += dn->get_name();
-      mdcache->mds->damage_table.notify_remote_link_damaged(
-          dnl->get_remote_ino(), path);
-      return nullptr;
+      add_remote_link_damage(get_dn_path(dn), "", remote_ino,
+                             get_dn_parent_ino(dn), header);
+      return ;
     }
-    MDSContext *ctx =
-        (!header->get_repair() && g_conf()->mds_force_hard_link_scrubbing)
-            ? (MDSContext *)(new C_RemoteInodeOpened(
-                  mdcache->mds, this, header, dn, dnl->get_remote_ino()))
-            : (MDSContext *)(new C_MDSInternalNoop());
 
+    MDSContext *ctx = (do_hardlink_scrub) ?
+      (MDSContext*)new C_RemoteInodeOpened(this, header, dn, remote_ino) :
+      (MDSContext*)(new C_MDSInternalNoop());
     mdcache->open_remote_dentry(dn, true, ctx);
+  } else if (do_hardlink_scrub) {
+    _enqueue(remote_inode, header, true, added,
+             {CInode::remote_link_info_t(std::move(get_dn_path(dn)), remote_ino,
+                                         get_dn_parent_ino(dn))});
   }
-  return remote_inode;
+}
+void ScrubStack::_validate_remote_inode_opened(int r, ScrubHeaderRef& header,
+                                               CDentry* dn)
+{
+
+  if (r >= 0) {
+    CDentry::linkage_t* dnl = dn->get_projected_linkage();
+    ceph_assert(dnl);
+    ceph_assert(dnl->is_remote());
+
+    string path = get_dn_path(dn);
+    inodeno_t parent_ino = get_dn_parent_ino(dn);
+    auto remote_ino = dnl->get_remote_ino();
+    CInode* remote_inode = mdcache->get_inode(remote_ino);
+    if (!remote_inode) {
+      add_remote_link_damage(path, "", remote_ino, parent_ino, header);
+    } else {
+      _enqueue(remote_inode, header, true, nullptr,
+               {CInode::remote_link_info_t(std::move(path), remote_ino,
+                                           parent_ino)});
+    }
+  } else {
+    // Most of error handling is in MDCache::_open_remote_dentry_finish,
+    // what's left is relevant scrub counter incrementing
+    header->inc_scrubbed_remote_link_count();
+  }
+  kick_off_scrubs();
 }
 
-void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
+bool ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children)
 {
   ceph_assert(dir != NULL);
   dout(10) << __func__ << " " << *dir << dendl;
@@ -540,7 +623,7 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
   if (!dir->is_complete()) {
     dir->fetch(new C_RetryScrub(this, dir), true); // already auth pinned
     dout(10) << __func__ << " incomplete, fetching" << dendl;
-    return;
+    return false;
   }
 
   ScrubHeaderRef header = dir->get_scrub_header();
@@ -574,17 +657,7 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
       if (dnl->is_primary()) {
         _enqueue(dnl->get_inode(), header, true, added_children);
       } else if (dnl->is_remote()) {
-        auto remote_ino = dnl->get_remote_ino();
-        CInode *remote_inode = remote_link_checkup(dn, header);
-        if (remote_inode && !header->get_repair() &&
-            g_conf()->mds_force_hard_link_scrubbing) {
-          std::string remote_path;
-          dir->get_inode()->make_path_string(remote_path);
-          remote_path += "/";
-          remote_path += dn->get_name();
-          _enqueue(remote_inode, header, true, added_children,
-                   {std::make_pair(std::move(remote_path), remote_ino)});
-        }
+        remote_link_checkup(dn, header, added_children);
       }
     }
   }
@@ -600,114 +673,8 @@ void ScrubStack::scrub_dirfrag(CDir *dir, bool *added_children, bool *done)
   dir->scrub_finished();
   dir->auth_unpin(this);
 
-  *done = true;
   dout(10) << __func__ << " done" << dendl;
-}
-
-void ScrubStack::scrub_file_inode(CInode *in)
-{
-  ScrubHeaderRef header = in->scrub_info()->header;
-  if (!in->scrub_info()->forward_scrub &&
-      !in->scrub_info()->remote_links.empty()) {
-    auto parent = in->get_projected_parent_dn();
-    if (mdcache->mds->damage_table.is_remote_damaged(in->ino()) ||
-        (parent && mdcache->mds->damage_table.is_dentry_damaged(
-                       parent->get_dir(), parent->get_name(), parent->last))) {
-      for (auto &[remote_link_path, remote_ino] :
-           in->scrub_info()->remote_links) {
-        add_remote_link_damage(remote_link_path, remote_ino, header);
-      }
-      in->scrub_finished();
-      return;
-    }
-  }
-
-  C_InodeValidated *fin = new C_InodeValidated(mdcache->mds, this, in);
-  // At this stage the DN is already past scrub_initialize, so
-  // it's in the cache, it has PIN_SCRUBQUEUE and it is authpinned
-  in->validate_disk_state(&fin->result, fin);
-}
-
-void ScrubStack::_validate_inode_done(CInode *in, int r,
-				      const CInode::validated_data &result)
-{
-  LogChannelRef clog = mdcache->mds->clog;
-  ScrubHeaderRef header = in->scrub_info()->header;
-
-  std::string path;
-  if (!result.passed_validation) {
-    // Build path string for use in messages
-    in->make_path_string(path, true);
-  }
-
-  if (result.backtrace.checked && !result.backtrace.passed &&
-      !result.backtrace.repaired)
-  {
-    // Record backtrace fails as remote linkage damage, as
-    // we may not be able to resolve hard links to this inode
-    mdcache->mds->damage_table.notify_remote_damaged(in->ino(), path);
-  } else if (result.inode.checked && !result.inode.passed &&
-             !result.inode.repaired) {
-    // Record damaged inode structures as damaged dentries as
-    // that is where they are stored
-    auto parent = in->get_projected_parent_dn();
-    if (parent) {
-      auto dir = parent->get_dir();
-      mdcache->mds->damage_table.notify_dentry(
-          dir->inode->ino(), dir->frag, parent->last, parent->get_name(), path);
-    }
-  }
-
-  // Inform the cluster log if we found an error
-  if (!result.passed_validation) {
-    if (result.all_damage_repaired()) {
-      clog->info() << "Scrub repaired inode " << in->ino()
-                   << " (" << path << ")";
-    } else {
-      clog->warn() << "Scrub error on inode " << in->ino()
-                   << " (" << path << ") see " << g_conf()->name
-                   << " log and `damage ls` output for details";
-    }
-
-    // Put the verbose JSON output into the MDS log for later inspection
-    JSONFormatter f;
-    result.dump(&f);
-    CachedStackStringStream css;
-    f.flush(*css);
-    derr << __func__ << " scrub error on inode " << *in << ": " << css->strv()
-         << dendl;
-  } else {
-    dout(10) << __func__ << " scrub passed on inode " << *in << dendl;
-  }
-
-  if (!in->scrub_info()->remote_links.empty()) {
-    if (!result.passed_validation) {
-      for (auto &[remote_link_path, remote_ino] :
-           in->scrub_info()->remote_links) {
-        add_remote_link_damage(remote_link_path, remote_ino, header);
-      }
-    } else {
-      CDentry *pdn = in->get_parent_dn();
-      if (pdn) {
-        CInode *diri = pdn->get_dir()->get_inode();
-        _enqueue(diri, header, true, nullptr,
-                 std::move(in->scrub_move_remote_links()));
-      } else {
-        header->inc_scrubbed_remote_link_count(
-            in->scrub_info()->remote_links.size());
-      }
-    }
-  }
-  in->scrub_reset_remote_links();
-
-  if (in->scrub_info()->forward_scrub && in->is_dir()) {
-    in->scrub_finished();
-    _enqueue(in, header, true);
-  } else {
-    in->scrub_finished();
-  }
-
-  header->inc_scrubbed_inode_count();
+  return true;
 }
 
 void ScrubStack::complete_control_contexts(int r) {

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -213,7 +213,7 @@ private:
    * @param dir The dirfrag to scrub (must be auth)
    * @param done set to true if we started to do final scrub
    */
-  void scrub_dirfrag(CDir *dir, bool *done);
+  void scrub_dirfrag(CDir *dir, bool *added_children, bool *done);
   /**
    * Scrub a directory-representing dentry.
    *

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -154,8 +154,13 @@ private:
   friend std::ostream &operator<<(std::ostream &os, const State &state);
 
   friend class C_InodeValidated;
+  friend class C_RemoteInodeOpened;
+  friend class C_RemoteLinkCheckFinished;
 
-  int _enqueue(MDSCacheObject *obj, ScrubHeaderRef& header, bool top);
+  int _enqueue(
+      MDSCacheObject *obj, ScrubHeaderRef &header, bool top,
+      bool *added = nullptr,
+      std::vector<std::pair<std::string, inodeno_t>> &&remote_links = {});
   /**
    * Remove the inode/dirfrag from the stack.
    */
@@ -189,6 +194,12 @@ private:
   void scrub_file_inode(CInode *in);
 
   /**
+   * Scrub a file inode.
+   * @param dn The remote dentry to identify
+   */
+  CInode *remote_link_checkup(CDentry *dn, ScrubHeaderRef &header);
+
+  /**
    * Callback from completion of CInode::validate_disk_state
    * @param in The inode we were validating
    * @param r The return status from validate_disk_state
@@ -211,6 +222,7 @@ private:
    * scrub of the dirfrag.
    *
    * @param dir The dirfrag to scrub (must be auth)
+   * @param added_children set to true if we pushed some of our children
    * @param done set to true if we started to do final scrub
    */
   void scrub_dirfrag(CDir *dir, bool *added_children, bool *done);
@@ -267,6 +279,8 @@ private:
 
   void handle_scrub(const cref_t<MMDSScrub> &m);
   void handle_scrub_stats(const cref_t<MMDSScrubStats> &m);
+  void add_remote_link_damage(const std::string &path, inodeno_t ino,
+                              ScrubHeaderRef &header);
 
   State state = STATE_IDLE;
   bool clear_stack = false;

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -157,10 +157,9 @@ private:
   friend class C_RemoteInodeOpened;
   friend class C_RemoteLinkCheckFinished;
 
-  int _enqueue(
-      MDSCacheObject *obj, ScrubHeaderRef &header, bool top,
-      bool *added = nullptr,
-      std::vector<std::pair<std::string, inodeno_t>> &&remote_links = {});
+  int _enqueue(MDSCacheObject *obj, ScrubHeaderRef &header, bool top,
+               bool *added = nullptr,
+               std::vector<CInode::remote_link_info_t> &&remote_links = {});
   /**
    * Remove the inode/dirfrag from the stack.
    */
@@ -197,7 +196,7 @@ private:
    * Scrub a file inode.
    * @param dn The remote dentry to identify
    */
-  CInode *remote_link_checkup(CDentry *dn, ScrubHeaderRef &header);
+  void remote_link_checkup(CDentry *dn, ScrubHeaderRef &header, bool* added);
 
   /**
    * Callback from completion of CInode::validate_disk_state
@@ -208,30 +207,32 @@ private:
   void _validate_inode_done(CInode *in, int r,
 			    const CInode::validated_data &result);
 
+  void _validate_remote_inode_opened(int r, ScrubHeaderRef& header,
+                                     CDentry* dn);
+
   /**
    * Scrub a directory inode. It queues child dirfrags, then does
    * final scrub of the inode.
    *
    * @param in The directory indoe to scrub
    * @param added_children set to true if we pushed some of our children
-   * @param done set to true if we started to do final scrub
    */
-  void scrub_dir_inode(CInode *in, bool *added_children, bool *done);
+  bool scrub_dir_inode(CInode* in, bool* added_children);
+  bool scrub_dir_inode_forward(CInode *in, bool *added_children);
   /**
    * Scrub a dirfrag. It queues child dentries, then does final
    * scrub of the dirfrag.
    *
    * @param dir The dirfrag to scrub (must be auth)
    * @param added_children set to true if we pushed some of our children
-   * @param done set to true if we started to do final scrub
    */
-  void scrub_dirfrag(CDir *dir, bool *added_children, bool *done);
+  bool scrub_dirfrag(CDir *dir, bool *added_children);
   /**
    * Scrub a directory-representing dentry.
    *
-   * @param in The directory inode we're doing final scrub on.
+   * @param in The inode we're doing final scrub on.
    */
-  void scrub_dir_inode_final(CInode *in);
+  void scrub_inode_validate(CInode *in);
   /**
    * Set scrub state
    * @param next_state State to move the scrub to.
@@ -280,7 +281,29 @@ private:
   void handle_scrub(const cref_t<MMDSScrub> &m);
   void handle_scrub_stats(const cref_t<MMDSScrubStats> &m);
   void add_remote_link_damage(const std::string &path, inodeno_t ino,
-                              ScrubHeaderRef &header);
+                              inodeno_t parent_ino, ScrubHeaderRef &header);
+  void add_remote_link_damage(const std::string &path,
+                              const std::string &head_path, inodeno_t ino,
+                              inodeno_t parent_ino, ScrubHeaderRef &header);
+
+  std::string get_dn_path(CDentry* dn) {
+    std::string path;
+    if (dn && dn->get_dir() && dn->get_dir()->get_inode()) {
+      dn->get_dir()->get_inode()->make_path_string(path);
+      path += "/";
+      path += dn->get_name();
+    } else {
+      path = "???";
+    }
+    return path;
+  }
+
+  inodeno_t get_dn_parent_ino(CDentry *dn) {
+    if (dn && dn->get_dir() && dn->get_dir()->get_inode()) {
+      return dn->get_dir()->get_inode()->ino();
+    }
+    return inodeno_t();
+  }
 
   State state = STATE_IDLE;
   bool clear_stack = false;

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -89,7 +89,9 @@ void DataScan::usage() {
          "[<data pool name> [<extra data pool "
          "name> ...]]\n"
       << "  cephfs-data-scan scan_inodes [--force-pool] [--force-corrupt] "
-         "[--worker_n N --worker_m M] [<data pool name>]\n"
+         "[--force-restore-all-ancestors] "
+         "[--worker_n N --worker_m M] [--damage-file PATH] "
+         "[--type 'TYPE|TYPE'] [--inode-file PATH] [<data pool name>]\n"
       << "  cephfs-data-scan pg_files <path> <pg id> [<pg id>...]\n"
       << "  cephfs-data-scan scan_links\n"
       << "\n"
@@ -100,6 +102,10 @@ void DataScan::usage() {
       << "    --worker_n: Worker number, range 0-(worker_m-1)\n"
       << "    --force-create-head-inode: force flushing inode 0th object in "
          "targeted scan_extents even when no extents are found\n"
+      << "    --force-restore-all-ancestors: force restoring all ancestor "
+         "dirfrags during targeted scan_inodes\n"
+      << "      with targeted scan_inodes (--damage-file/--inode-file), "
+         "requires single worker (--worker_n 0 --worker_m 1)\n"
       << "\n"
       << "  cephfs-data-scan scan_frags [--force-corrupt]\n"
       << "  cephfs-data-scan cleanup [<data pool name>]\n"
@@ -165,8 +171,9 @@ bool DataScan::parse_kwarg(
     dout(10) << "Applying tag filter: '" << filter_tag << "'" << dendl;
     return true;
   } else if (arg == std::string("--damage-file")) {
-    if (command != "scan_extents") {
-      std::cerr << "Option '--damage-file' is only valid with scan_extents"
+    if (command != "scan_extents" && command != "scan_inodes") {
+      std::cerr << "Option '--damage-file' is only valid with scan_extents "
+                   "or scan_inodes"
                 << std::endl;
       *r = -EINVAL;
       return false;
@@ -174,8 +181,9 @@ bool DataScan::parse_kwarg(
     damage_file_path = val;
     return true;
   } else if (arg == std::string("--type")) {
-    if (command != "scan_extents") {
-      std::cerr << "Option '--type' is only valid with scan_extents"
+    if (command != "scan_extents" && command != "scan_inodes") {
+      std::cerr << "Option '--type' is only valid with scan_extents or "
+                   "scan_inodes"
                 << std::endl;
       *r = -EINVAL;
       return false;
@@ -192,8 +200,9 @@ bool DataScan::parse_kwarg(
     damage_type_all = false;
     return true;
   } else if (arg == std::string("--inode-file")) {
-    if (command != "scan_extents") {
-      std::cerr << "Option '--inode-file' is only valid with scan_extents"
+    if (command != "scan_extents" && command != "scan_inodes") {
+      std::cerr << "Option '--inode-file' is only valid with scan_extents "
+                   "or scan_inodes"
                 << std::endl;
       *r = -EINVAL;
       return false;
@@ -309,6 +318,9 @@ bool DataScan::parse_arg(
   } else if (arg == "--force-create-head-inode") {
     force_create_head_inode = true;
     return true;
+  } else if (arg == "--force-restore-all-ancestors") {
+    force_restore_all_ancestors = true;
+    return true;
   } else {
     return false;
   }
@@ -395,22 +407,28 @@ int DataScan::main(const std::vector<const char*> &args)
     return -EINVAL;
   }
 
-  if (command != "scan_extents") {
+  if (command != "scan_extents" && command != "scan_inodes") {
     if (!damage_file_path.empty()) {
-      std::cerr << "Option '--damage-file' is only valid with scan_extents"
+      std::cerr << "Option '--damage-file' is only valid with scan_extents "
+                   "or scan_inodes"
                 << std::endl;
       return -EINVAL;
     }
     if (damage_type_filter_set) {
-      std::cerr << "Option '--type' is only valid with scan_extents"
+      std::cerr << "Option '--type' is only valid with scan_extents or "
+                   "scan_inodes"
                 << std::endl;
       return -EINVAL;
     }
     if (!inode_file_path.empty()) {
-      std::cerr << "Option '--inode-file' is only valid with scan_extents"
+      std::cerr << "Option '--inode-file' is only valid with scan_extents "
+                   "or scan_inodes"
                 << std::endl;
       return -EINVAL;
     }
+  }
+
+  if (command != "scan_extents") {
     if (extent_period_set) {
       std::cerr << "Option '--extent-period' is only valid with scan_extents"
                 << std::endl;
@@ -429,12 +447,27 @@ int DataScan::main(const std::vector<const char*> &args)
     }
   }
 
+  if (command != "scan_inodes") {
+    if (force_restore_all_ancestors) {
+      std::cerr << "Option '--force-restore-all-ancestors' is only valid with "
+                   "scan_inodes"
+                << std::endl;
+      return -EINVAL;
+    }
+  }
+
   if (command == "scan_extents" && (extent_period_set || extent_limit_set) &&
       damage_file_path.empty() && inode_file_path.empty()) {
     std::cerr << "Options '--extent-period'/'--extent-limit' require "
                  "'--damage-file' or "
                  "'--inode-file'"
               << std::endl;
+    return -EINVAL;
+  }
+
+  if ((command == "scan_extents" || command == "scan_inodes") &&
+      damage_type_filter_set && damage_file_path.empty()) {
+    std::cerr << "Option '--type' requires '--damage-file'" << std::endl;
     return -EINVAL;
   }
 
@@ -446,9 +479,28 @@ int DataScan::main(const std::vector<const char*> &args)
     return -EINVAL;
   }
 
-  if (command == "scan_extents" &&
-      !damage_file_path.empty() &&
-      !damage_type_filter_set) {
+  if (command == "scan_inodes" && force_restore_all_ancestors &&
+      damage_file_path.empty() && inode_file_path.empty()) {
+    std::cerr << "Option '--force-restore-all-ancestors' requires "
+                 "'--damage-file' or '--inode-file'"
+              << std::endl;
+    return -EINVAL;
+  }
+
+  const bool targeted_scan_inodes =
+      command == "scan_inodes" &&
+      (!damage_file_path.empty() || !inode_file_path.empty());
+  if (targeted_scan_inodes && force_restore_all_ancestors &&
+      (m != 1 || n != 0)) {
+    std::cerr << "Targeted 'scan_inodes' with "
+                 "'--force-restore-all-ancestors' requires single worker "
+                 "('--worker_n 0 --worker_m 1')"
+              << std::endl;
+    return -EINVAL;
+  }
+
+  if ((command == "scan_extents" || command == "scan_inodes") &&
+      !damage_file_path.empty() && !damage_type_filter_set) {
     damage_type_all = true;
   }
 
@@ -467,7 +519,7 @@ int DataScan::main(const std::vector<const char*> &args)
 
   // Default to output to metadata pool
   if (driver == NULL) {
-    driver = new MetadataDriver();
+    driver = new MetadataDriver(this);
     driver->set_force_corrupt(force_corrupt);
     driver->set_force_init(force_init);
     dout(4) << "Using metadata pool output" << dendl;
@@ -587,7 +639,8 @@ int DataScan::main(const std::vector<const char*> &args)
   }
 
   // Initialize metadata_io from MDSMap for scan_frags
-  if (command == "scan_frags" || command == "scan_links") {
+  if (command == "scan_frags" || command == "scan_links" ||
+      command == "scan_inodes") {
     const auto fs = fsmap->get_filesystem(fscid);
     if (fs == nullptr) {
       std::cerr << "Filesystem id " << fscid << " does not exist" << std::endl;
@@ -599,7 +652,7 @@ int DataScan::main(const std::vector<const char*> &args)
     int r = rados.pool_reverse_lookup(metadata_pool_id, &metadata_pool_name);
     if (r < 0) {
       std::cerr << "Pool " << metadata_pool_id
-        << " identified in MDS map not found in RADOS!" << std::endl;
+                << " identified in MDS map not found in RADOS!" << std::endl;
       return r;
     }
 
@@ -613,6 +666,12 @@ int DataScan::main(const std::vector<const char*> &args)
 
   // Finally, dispatch command
   if (command == "scan_inodes") {
+    if (!damage_file_path.empty()) {
+      return scan_inodes_for_damage_file();
+    }
+    if (!inode_file_path.empty()) {
+      return scan_inodes_for_inode_file();
+    }
     return scan_inodes();
   } else if (command == "scan_extents") {
     if (!damage_file_path.empty()) {
@@ -1139,6 +1198,177 @@ int DataScan::scan_extents_for_inode_file()
   return 0;
 }
 
+int DataScan::scan_inodes_for_damage_file() {
+  bool roots_present;
+  int r = driver->check_roots(&roots_present);
+  if (r != 0) {
+    derr << "Unexpected error checking roots: '" << cpp_strerror(r) << "'"
+         << dendl;
+    return r;
+  }
+
+  if (!roots_present) {
+    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
+                 "one node before running 'scan_inodes'"
+              << std::endl;
+    return -EIO;
+  }
+
+  std::ifstream input(damage_file_path);
+  if (!input.is_open()) {
+    int err = errno ? -errno : -ENOENT;
+    std::cerr << "Failed to open damage file '" << damage_file_path
+              << "': " << cpp_strerror(err) << std::endl;
+    return err;
+  }
+
+  uint64_t candidate_index = 0;
+  uint64_t line_no = 0;
+  std::string line;
+  while (std::getline(input, line)) {
+    ++line_no;
+    if (trim_whitespace(line).empty()) {
+      continue;
+    }
+
+    JSONParser parser;
+    if (!parser.parse(line.c_str(), static_cast<int>(line.size()))) {
+      std::cerr << "Invalid JSON on line " << line_no << ": "
+                << describe_json_parse_error(line) << std::endl;
+      return -EINVAL;
+    }
+    if (!parser.is_object()) {
+      std::cerr << "Invalid damage entry on line " << line_no
+                << ": JSON value must be an object" << std::endl;
+      return -EINVAL;
+    }
+
+    std::string damage_type;
+    unsigned long long ino = 0;
+    try {
+      JSONDecoder::decode_json("damage_type", damage_type, &parser, true);
+      JSONDecoder::decode_json("ino", ino, &parser, true);
+    } catch (const JSONDecoder::err &e) {
+      std::cerr << "Invalid damage entry on line " << line_no << ": "
+                << e.what() << std::endl;
+      return -EINVAL;
+    }
+
+    JSONObj *damage_type_obj = parser.find_obj("damage_type");
+    ceph_assert(damage_type_obj != nullptr);
+    if (!damage_type_obj->get_data_val().quoted) {
+      std::cerr << "Invalid damage entry on line " << line_no
+                << ": damage_type must be a string" << std::endl;
+      return -EINVAL;
+    }
+
+    JSONObj *ino_obj = parser.find_obj("ino");
+    ceph_assert(ino_obj != nullptr);
+    if (ino_obj->get_data_val().quoted) {
+      std::cerr << "Invalid damage entry on line " << line_no
+                << ": ino must be a numeric JSON value" << std::endl;
+      return -EINVAL;
+    }
+
+    if (trim_whitespace(damage_type).empty()) {
+      std::cerr << "Invalid damage entry on line " << line_no
+                << ": damage_type must be a non-empty string" << std::endl;
+      return -EINVAL;
+    }
+
+    bool type_matched = damage_type_all;
+    if (!damage_type_all) {
+      type_matched =
+          std::find(damage_type_tokens.begin(), damage_type_tokens.end(),
+                    damage_type) != damage_type_tokens.end();
+    }
+    if (!type_matched) {
+      continue;
+    }
+
+    inodeno_t selected_ino = static_cast<inodeno_t>(ino);
+    if ((candidate_index % m) == n) {
+      dout(10) << "selected damage entry line=" << line_no << " damage_type='"
+               << damage_type << "'"
+               << " ino=0x" << std::hex << ino << std::dec
+               << " candidate_index=" << candidate_index << " worker=" << n
+               << "/" << m << dendl;
+      const std::string oid = format_extent_oid(selected_ino, 0);
+      r = scan_inode_from_oid(oid, selected_ino, 0,
+                              force_restore_all_ancestors);
+      if (r < 0) {
+        return r;
+      }
+    }
+
+    ++candidate_index;
+  }
+
+  return 0;
+}
+
+int DataScan::scan_inodes_for_inode_file() {
+  bool roots_present;
+  int r = driver->check_roots(&roots_present);
+  if (r != 0) {
+    derr << "Unexpected error checking roots: '" << cpp_strerror(r) << "'"
+         << dendl;
+    return r;
+  }
+
+  if (!roots_present) {
+    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
+                 "one node before running 'scan_inodes'"
+              << std::endl;
+    return -EIO;
+  }
+
+  std::ifstream input(inode_file_path);
+  if (!input.is_open()) {
+    int err = errno ? -errno : -ENOENT;
+    std::cerr << "Failed to open inode file '" << inode_file_path
+              << "': " << cpp_strerror(err) << std::endl;
+    return err;
+  }
+
+  uint64_t candidate_index = 0;
+  uint64_t line_no = 0;
+  std::string line;
+  while (std::getline(input, line)) {
+    ++line_no;
+
+    std::string trimmed = trim_whitespace(line);
+    if (trimmed.empty()) {
+      continue;
+    }
+
+    auto ino_val = ceph::parse<uint64_t>(trimmed);
+    if (!ino_val) {
+      std::cerr << "Invalid inode entry on line " << line_no
+                << ": expected unsigned integer inode" << std::endl;
+      return -EINVAL;
+    }
+
+    inodeno_t selected_ino(*ino_val);
+    if ((candidate_index % m) == n) {
+      dout(10) << "selected inode entry line=" << line_no << " ino=0x"
+               << std::hex << static_cast<uint64_t>(selected_ino) << std::dec
+               << " candidate_index=" << candidate_index << " worker=" << n
+               << "/" << m << dendl;
+      const std::string oid = format_extent_oid(selected_ino, 0);
+      r = scan_inode_from_oid(oid, selected_ino, 0,
+                              force_restore_all_ancestors);
+      if (r < 0) {
+        return r;
+      }
+    }
+
+    ++candidate_index;
+  }
+
+  return 0;
+}
+
 int DataScan::probe_filter(librados::IoCtx &ioctx)
 {
   bufferlist filter_bl;
@@ -1247,27 +1477,10 @@ int DataScan::forall_objects(
   return r;
 }
 
-int DataScan::scan_inodes()
-{
-  bool roots_present;
-  int r = driver->check_roots(&roots_present);
-  if (r != 0) {
-    derr << "Unexpected error checking roots: '"
-      << cpp_strerror(r) << "'" << dendl;
-    return r;
-  }
+int DataScan::scan_inode_from_oid(const std::string &oid, uint64_t obj_name_ino,
+                                  uint64_t obj_name_offset,
+                                  bool force_restore_ancestors) {
 
-  if (!roots_present) {
-    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
-      "one node before running 'scan_inodes'" << std::endl;
-    return -EIO;
-  }
-
-  return forall_objects(data_io, true, [this](
-        std::string const &oid,
-        uint64_t obj_name_ino,
-        uint64_t obj_name_offset) -> int
-  {
     int r = 0;
 
     dout(10) << "handling object "
@@ -1495,7 +1708,8 @@ int DataScan::scan_inodes()
         }
       } else {
         /* Happy case: we will inject a named dentry for this inode */
-        r = driver->inject_with_backtrace(backtrace, dentry);
+        r = driver->inject_with_backtrace(backtrace, dentry,
+                                          force_restore_ancestors);
         if (r < 0) {
           dout(4) << "Error injecting 0x" << std::hex << backtrace.ino
             << std::dec << " with backtrace: " << cpp_strerror(r) << dendl;
@@ -1520,7 +1734,30 @@ int DataScan::scan_inodes()
     }
 
     return r;
-  });
+}
+
+int DataScan::scan_inodes() {
+  bool roots_present;
+  int r = driver->check_roots(&roots_present);
+  if (r != 0) {
+    derr << "Unexpected error checking roots: '" << cpp_strerror(r) << "'"
+         << dendl;
+    return r;
+  }
+
+  if (!roots_present) {
+    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
+                 "one node before running 'scan_inodes'"
+              << std::endl;
+    return -EIO;
+  }
+
+  return forall_objects(data_io, true,
+                        [this](std::string const &oid, uint64_t obj_name_ino,
+                               uint64_t obj_name_offset) -> int {
+                          return scan_inode_from_oid(oid, obj_name_ino,
+                                                     obj_name_offset);
+                        });
 }
 
 int DataScan::cleanup()
@@ -1970,11 +2207,23 @@ int DataScan::scan_frags()
     return -EIO;
   }
 
-  return forall_objects(metadata_io, true, [this](
-        std::string const &oid,
-        uint64_t obj_name_ino,
-        uint64_t obj_name_offset) -> int
-  {
+  return forall_objects(metadata_io, true,
+                        [this](std::string const &oid, uint64_t obj_name_ino,
+                               uint64_t obj_name_offset) -> int {
+                          return scan_frag_from_oid(oid, obj_name_ino,
+                                                    obj_name_offset);
+                        });
+}
+
+int DataScan::scan_frag_from_oid(const std::string &oid, uint64_t obj_name_ino,
+                                 uint64_t obj_name_offset,
+                                 bool force_restore_ancestors,
+                                 std::unordered_set<uint64_t> &&inode_set) {
+  if (force_restore_ancestors &&
+      inode_set.find(obj_name_ino) != inode_set.end()) {
+    derr << "Found cycle while restoring ancestors" << dendl;
+    return -EINVAL;
+  }
     int r = 0;
     r = parse_oid(oid, &obj_name_ino, &obj_name_offset);
     if (r != 0) {
@@ -2086,7 +2335,8 @@ int DataScan::scan_frags()
         }
       } else {
         /* Happy case: we will inject a named dentry for this inode */
-        r = driver->inject_with_backtrace(backtrace, dentry);
+        r = driver->inject_with_backtrace(
+            backtrace, dentry, force_restore_ancestors, std::move(inode_set));
         if (r < 0) {
           dout(4) << "Error injecting 0x" << std::hex << backtrace.ino
             << std::dec << " with backtrace: " << cpp_strerror(r) << dendl;
@@ -2111,7 +2361,6 @@ int DataScan::scan_frags()
     }
 
     return r;
-  });
 }
 
 int MetadataTool::read_fnode(
@@ -2399,11 +2648,9 @@ int MetadataDriver::get_frag_of(
   }
 }
 
-
 int MetadataDriver::inject_with_backtrace(
-    const inode_backtrace_t &backtrace, const InodeStore &dentry)
-    
-{
+    const inode_backtrace_t &backtrace, const InodeStore &dentry,
+    bool force_inject_ancestors, std::unordered_set<uint64_t> &&inode_set) {
 
   // On dirfrags
   // ===========
@@ -2457,6 +2704,10 @@ int MetadataDriver::inject_with_backtrace(
   dout(10) << "  inode: 0x" << std::hex << ino << std::dec << dendl;
   for (std::vector<inode_backpointer_t>::const_iterator i = backtrace.ancestors.begin();
       i != backtrace.ancestors.end(); ++i) {
+    if (force_inject_ancestors && !inode_set.insert(ino).second) {
+      derr << "Found cycle while restoring ancestors" << dendl;
+      return -EINVAL;
+    }
     const inode_backpointer_t &backptr = *i;
     dout(10) << "  backptr: 0x" << std::hex << backptr.dirino << std::dec
       << "/" << backptr.dname << dendl;
@@ -2567,7 +2818,13 @@ int MetadataDriver::inject_with_backtrace(
       // injecting data.  If there are in fact missing ancestors, this
       // should be fixed up using a separate tool scanning the metadata
       // pool.
-      break;
+      if (force_inject_ancestors) {
+        return dscan->scan_frag_from_oid(
+            InodeStore::get_object_name(parent_ino, frag_t(), "").name,
+            parent_ino, 0, force_inject_ancestors, std::move(inode_set));
+      } else {
+        break;
+      }
     } else {
       // Proceed up the backtrace, creating parents
       ino = parent_ino;
@@ -2757,11 +3014,9 @@ int LocalFileDriver::inject_data(
   return 0;
 }
 
-
 int LocalFileDriver::inject_with_backtrace(
-    const inode_backtrace_t &bt,
-    const InodeStore &dentry)
-{
+    const inode_backtrace_t &bt, const InodeStore &dentry,
+    bool force_inject_ancestors, std::unordered_set<uint64_t> &&inode_set) {
   std::string path_builder = path;
 
   // Iterate through backtrace creating directory parents

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -336,15 +336,13 @@ bool DataScan::parse_kwarg(
       return false;
     }
 
-    std::vector<std::string> tokens;
+    std::set<std::string> tokens;
     *r = parse_damage_type_expr(val, &tokens);
     if (*r < 0) {
       return false;
     }
     damage_type_expr = val;
     damage_type_tokens = tokens;
-    damage_type_filter_set = true;
-    damage_type_all = false;
     return true;
   } else if (arg == std::string("--inode-file")) {
     if (command != "scan_extents" && command != "scan_inodes") {
@@ -412,7 +410,7 @@ bool DataScan::parse_kwarg(
 }
 
 int DataScan::parse_damage_type_expr(const std::string &expr,
-                                     std::vector<std::string> *tokens) {
+                                     std::set<std::string> *tokens) {
   tokens->clear();
   std::string trimmed_expr = trim_whitespace(expr);
   if (trimmed_expr.empty()) {
@@ -434,7 +432,7 @@ int DataScan::parse_damage_type_expr(const std::string &expr,
       return -EINVAL;
     }
     if (seen.insert(token).second) {
-      tokens->push_back(token);
+      tokens->insert(token);
     }
 
     if (sep == std::string::npos) {
@@ -559,7 +557,7 @@ int DataScan::main(const std::vector<const char*> &args)
                 << std::endl;
       return -EINVAL;
     }
-    if (damage_type_filter_set) {
+    if (damage_type_tokens.size()) {
       std::cerr << "Option '--type' is only valid with scan_extents or "
                    "scan_inodes"
                 << std::endl;
@@ -611,7 +609,7 @@ int DataScan::main(const std::vector<const char*> &args)
   }
 
   if ((command == "scan_extents" || command == "scan_inodes") &&
-      damage_type_filter_set && damage_file_path.empty()) {
+      damage_type_tokens.size() && damage_file_path.empty()) {
     std::cerr << "Option '--type' requires '--damage-file'" << std::endl;
     return -EINVAL;
   }
@@ -642,11 +640,6 @@ int DataScan::main(const std::vector<const char*> &args)
                  "('--worker_n 0 --worker_m 1')"
               << std::endl;
     return -EINVAL;
-  }
-
-  if ((command == "scan_extents" || command == "scan_inodes") &&
-      !damage_file_path.empty() && !damage_type_filter_set) {
-    damage_type_all = true;
   }
 
   // If caller didn't specify a namespace, try to pick
@@ -1018,6 +1011,33 @@ std::string format_extent_oid(inodeno_t ino, uint64_t extent_id) {
   return std::string(buf);
 }
 
+void DataScan::update_accumulate_result(AccumulateResult *accum_res,
+                                        const uint64_t obj_index,
+                                        const uint64_t obj_size,
+                                        const int64_t obj_pool_id,
+                                        const time_t mtime) {
+  ceph_assert(accum_res != nullptr);
+
+  if (obj_index > accum_res->ceiling_obj_index ||
+      (obj_index == accum_res->ceiling_obj_index &&
+       accum_res->ceiling_obj_size == 0)) {
+    accum_res->ceiling_obj_index = obj_index;
+    accum_res->ceiling_obj_size = obj_size;
+  }
+
+  if (obj_size > accum_res->max_obj_size) {
+    accum_res->max_obj_size = obj_size;
+  }
+
+  if (mtime > accum_res->max_mtime) {
+    accum_res->max_mtime = mtime;
+  }
+
+  if (obj_pool_id != -1) {
+    accum_res->obj_pool_id = obj_pool_id;
+  }
+}
+
 int DataScan::scan_extent_for_inode(
     inodeno_t ino, const std::vector<librados::IoCtx *> &data_ios) {
   ceph_assert(!data_ios.empty());
@@ -1026,11 +1046,10 @@ int DataScan::scan_extent_for_inode(
   bool found_extent = false;
   uint64_t window_start = 0;
   while (window_start < extent_limit) {
-    bool window_productive = false;
     bool all_stat_failed = true;
 
     uint64_t window_end = window_start + extent_period;
-    if (window_end < window_start || window_end > extent_limit) {
+    if (window_end > extent_limit) {
       window_end = extent_limit;
     }
     for (uint64_t extent_id = window_start; extent_id < window_end;
@@ -1050,23 +1069,12 @@ int DataScan::scan_extent_for_inode(
         all_stat_failed = false;
         int64_t obj_pool_id =
             data_io.get_id() != ioctx->get_id() ? ioctx->get_id() : -1;
-
-        r = ClsCephFSClient::accumulate_inode_metadata(data_io, ino, extent_id,
-                                                       size, obj_pool_id, mtime,
-                                                       &accum_res, false);
-        if (r < 0) {
-          derr << "Failed to accumulate metadata for inode 0x" << std::hex
-               << static_cast<uint64_t>(ino) << std::dec << " from '" << oid
-               << "': " << cpp_strerror(r) << dendl;
-          return r;
-        }
-
-        window_productive = true;
+        update_accumulate_result(&accum_res, extent_id, size, obj_pool_id, mtime);
         found_extent = true;
       }
     }
 
-    if (!window_productive && all_stat_failed) {
+    if (all_stat_failed) {
       break;
     }
 
@@ -1164,201 +1172,7 @@ int DataScan::scan_extents()
   return 0;
 }
 
-int DataScan::scan_extents_for_damage_file()
-{
-  if (m == 0) {
-    std::cerr << "Invalid worker count " << m << ": must be > 0" << std::endl;
-    return -EINVAL;
-  }
-  if (n >= m) {
-    std::cerr << "Invalid worker number " << n
-              << ": must be in range [0, " << (m - 1) << "]" << std::endl;
-    return -EINVAL;
-  }
-
-  std::ifstream input(damage_file_path);
-  if (!input.is_open()) {
-    int err = errno ? -errno : -ENOENT;
-    std::cerr << "Failed to open damage file '" << damage_file_path << "': "
-              << cpp_strerror(err) << std::endl;
-    return err;
-  }
-
-  std::vector<librados::IoCtx *> data_ios;
-  data_ios.push_back(&data_io);
-  for (auto &extra_data_io : extra_data_ios) {
-    data_ios.push_back(&extra_data_io);
-  }
-
-  uint64_t candidate_index = 0;
-  uint64_t line_no = 0;
-  std::string line;
-  while (std::getline(input, line)) {
-    ++line_no;
-    if (trim_whitespace(line).empty()) {
-      continue;
-    }
-
-    JSONParser parser;
-    if (!parser.parse(line.c_str(), static_cast<int>(line.size()))) {
-      std::cerr << "Invalid JSON on line " << line_no
-                << ": " << describe_json_parse_error(line)
-                << std::endl;
-      return -EINVAL;
-    }
-    if (!parser.is_object()) {
-      std::cerr << "Invalid damage entry on line " << line_no
-                << ": JSON value must be an object" << std::endl;
-      return -EINVAL;
-    }
-
-    std::string damage_type;
-    unsigned long long ino = 0;
-    try {
-      JSONDecoder::decode_json("damage_type", damage_type, &parser, true);
-      JSONDecoder::decode_json("ino", ino, &parser, true);
-    } catch (const JSONDecoder::err &e) {
-      std::cerr << "Invalid damage entry on line " << line_no
-                << ": " << e.what() << std::endl;
-      return -EINVAL;
-    }
-
-    JSONObj *damage_type_obj = parser.find_obj("damage_type");
-    ceph_assert(damage_type_obj != nullptr);
-    if (!damage_type_obj->get_data_val().quoted) {
-      std::cerr << "Invalid damage entry on line " << line_no
-                << ": damage_type must be a string" << std::endl;
-      return -EINVAL;
-    }
-
-    JSONObj *ino_obj = parser.find_obj("ino");
-    ceph_assert(ino_obj != nullptr);
-    if (ino_obj->get_data_val().quoted) {
-      std::cerr << "Invalid damage entry on line " << line_no
-                << ": ino must be a numeric JSON value" << std::endl;
-      return -EINVAL;
-    }
-
-    if (trim_whitespace(damage_type).empty()) {
-      std::cerr << "Invalid damage entry on line " << line_no
-                << ": damage_type must be a non-empty string" << std::endl;
-      return -EINVAL;
-    }
-
-    bool type_matched = damage_type_all;
-    if (!damage_type_all) {
-      type_matched = std::find(damage_type_tokens.begin(),
-                               damage_type_tokens.end(),
-                               damage_type) != damage_type_tokens.end();
-    }
-    if (!type_matched) {
-      continue;
-    }
-
-    if ((candidate_index % m) == n) {
-      dout(10) << "selected damage entry line=" << line_no
-               << " damage_type='" << damage_type << "'"
-               << " ino=0x" << std::hex << ino << std::dec
-               << " candidate_index=" << candidate_index
-               << " worker=" << n << "/" << m << dendl;
-
-      int r = scan_extent_for_inode(static_cast<inodeno_t>(ino), data_ios);
-      if (r < 0) {
-        std::cerr << "Failed targeted extent scan for inode 0x" << std::hex
-                  << ino << std::dec << ": " << cpp_strerror(r) << std::endl;
-        return r;
-      }
-    }
-
-    ++candidate_index;
-  }
-
-  return 0;
-}
-
-int DataScan::scan_extents_for_inode_file()
-{
-  if (m == 0) {
-    std::cerr << "Invalid worker count " << m << ": must be > 0" << std::endl;
-    return -EINVAL;
-  }
-  if (n >= m) {
-    std::cerr << "Invalid worker number " << n
-              << ": must be in range [0, " << (m - 1) << "]" << std::endl;
-    return -EINVAL;
-  }
-
-  std::ifstream input(inode_file_path);
-  if (!input.is_open()) {
-    int err = errno ? -errno : -ENOENT;
-    std::cerr << "Failed to open inode file '" << inode_file_path << "': "
-              << cpp_strerror(err) << std::endl;
-    return err;
-  }
-
-  std::vector<librados::IoCtx *> data_ios;
-  data_ios.push_back(&data_io);
-  for (auto &extra_data_io : extra_data_ios) {
-    data_ios.push_back(&extra_data_io);
-  }
-
-  uint64_t candidate_index = 0;
-  uint64_t line_no = 0;
-  std::string line;
-  while (std::getline(input, line)) {
-    ++line_no;
-
-    std::string trimmed = trim_whitespace(line);
-    if (trimmed.empty()) {
-      continue;
-    }
-
-    auto ino_val = ceph::parse<uint64_t>(trimmed);
-    if (!ino_val) {
-      std::cerr << "Invalid inode entry on line " << line_no
-                << ": expected unsigned integer inode" << std::endl;
-      return -EINVAL;
-    }
-    inodeno_t ino(*ino_val);
-
-    if ((candidate_index % m) == n) {
-      dout(10) << "selected inode entry line=" << line_no
-               << " ino=0x" << std::hex
-               << static_cast<uint64_t>(ino) << std::dec
-               << " candidate_index=" << candidate_index
-               << " worker=" << n << "/" << m << dendl;
-
-      int r = scan_extent_for_inode(ino, data_ios);
-      if (r < 0) {
-        std::cerr << "Failed targeted extent scan for inode 0x" << std::hex
-                  << static_cast<uint64_t>(ino) << std::dec << ": "
-                  << cpp_strerror(r) << std::endl;
-        return r;
-      }
-    }
-
-    ++candidate_index;
-  }
-
-  return 0;
-}
-
-int DataScan::scan_inodes_for_damage_file() {
-  bool roots_present;
-  int r = driver->check_roots(&roots_present);
-  if (r != 0) {
-    derr << "Unexpected error checking roots: '" << cpp_strerror(r) << "'"
-         << dendl;
-    return r;
-  }
-
-  if (!roots_present) {
-    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
-                 "one node before running 'scan_inodes'"
-              << std::endl;
-    return -EIO;
-  }
-
+int DataScan::for_entry_in_damage_file(std::function<int(uint64_t)> handler) {
   std::ifstream input(damage_file_path);
   if (!input.is_open()) {
     int err = errno ? -errno : -ENOENT;
@@ -1389,7 +1203,7 @@ int DataScan::scan_inodes_for_damage_file() {
     }
 
     std::string damage_type;
-    unsigned long long ino = 0;
+    uint64_t ino = 0;
     try {
       JSONDecoder::decode_json("damage_type", damage_type, &parser, true);
       JSONDecoder::decode_json("ino", ino, &parser, true);
@@ -1421,26 +1235,23 @@ int DataScan::scan_inodes_for_damage_file() {
       return -EINVAL;
     }
 
-    bool type_matched = damage_type_all;
-    if (!damage_type_all) {
+    bool type_matched = damage_type_tokens.empty();
+    if (!damage_type_tokens.empty()) {
       type_matched =
-          std::find(damage_type_tokens.begin(), damage_type_tokens.end(),
-                    damage_type) != damage_type_tokens.end();
+          damage_type_tokens.find(damage_type) != damage_type_tokens.end();
     }
     if (!type_matched) {
       continue;
     }
 
-    inodeno_t selected_ino = static_cast<inodeno_t>(ino);
     if ((candidate_index % m) == n) {
       dout(10) << "selected damage entry line=" << line_no << " damage_type='"
                << damage_type << "'"
                << " ino=0x" << std::hex << ino << std::dec
                << " candidate_index=" << candidate_index << " worker=" << n
                << "/" << m << dendl;
-      const std::string oid = format_extent_oid(selected_ino, 0);
-      r = scan_inode_from_oid(oid, selected_ino, 0,
-                              force_restore_all_ancestors);
+
+      int r = handler(ino);
       if (r < 0) {
         return r;
       }
@@ -1448,26 +1259,38 @@ int DataScan::scan_inodes_for_damage_file() {
 
     ++candidate_index;
   }
-
   return 0;
 }
 
-int DataScan::scan_inodes_for_inode_file() {
-  bool roots_present;
-  int r = driver->check_roots(&roots_present);
-  if (r != 0) {
-    derr << "Unexpected error checking roots: '" << cpp_strerror(r) << "'"
-         << dendl;
-    return r;
+int DataScan::scan_extents_for_damage_file() {
+  if (m == 0) {
+    std::cerr << "Invalid worker count " << m << ": must be > 0" << std::endl;
+    return -EINVAL;
+  }
+  if (n >= m) {
+    std::cerr << "Invalid worker number " << n << ": must be in range [0, "
+              << (m - 1) << "]" << std::endl;
+    return -EINVAL;
   }
 
-  if (!roots_present) {
-    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
-                 "one node before running 'scan_inodes'"
-              << std::endl;
-    return -EIO;
+  std::vector<librados::IoCtx *> data_ios;
+  data_ios.push_back(&data_io);
+  for (auto &extra_data_io : extra_data_ios) {
+    data_ios.push_back(&extra_data_io);
   }
 
+  int r = for_entry_in_damage_file([&](uint64_t ino) -> int {
+    int ret = scan_extent_for_inode(static_cast<inodeno_t>(ino), data_ios);
+    if (ret < 0) {
+      std::cerr << "Failed targeted extent scan for inode 0x" << std::hex << ino
+                << std::dec << ": " << cpp_strerror(ret) << std::endl;
+    }
+    return ret;
+  });
+  return r;
+}
+
+int DataScan::for_entry_in_inode_file(std::function<int(uint64_t)> handler) {
   std::ifstream input(inode_file_path);
   if (!input.is_open()) {
     int err = errno ? -errno : -ENOENT;
@@ -1493,16 +1316,15 @@ int DataScan::scan_inodes_for_inode_file() {
                 << ": expected unsigned integer inode" << std::endl;
       return -EINVAL;
     }
+    inodeno_t ino(*ino_val);
 
-    inodeno_t selected_ino(*ino_val);
     if ((candidate_index % m) == n) {
       dout(10) << "selected inode entry line=" << line_no << " ino=0x"
-               << std::hex << static_cast<uint64_t>(selected_ino) << std::dec
+               << std::hex << static_cast<uint64_t>(ino) << std::dec
                << " candidate_index=" << candidate_index << " worker=" << n
                << "/" << m << dendl;
-      const std::string oid = format_extent_oid(selected_ino, 0);
-      r = scan_inode_from_oid(oid, selected_ino, 0,
-                              force_restore_all_ancestors);
+
+      int r = handler(ino);
       if (r < 0) {
         return r;
       }
@@ -1512,6 +1334,94 @@ int DataScan::scan_inodes_for_inode_file() {
   }
 
   return 0;
+}
+
+int DataScan::scan_extents_for_inode_file() {
+  if (m == 0) {
+    std::cerr << "Invalid worker count " << m << ": must be > 0" << std::endl;
+    return -EINVAL;
+  }
+  if (n >= m) {
+    std::cerr << "Invalid worker number " << n << ": must be in range [0, "
+              << (m - 1) << "]" << std::endl;
+    return -EINVAL;
+  }
+
+  std::vector<librados::IoCtx *> data_ios;
+  data_ios.push_back(&data_io);
+  for (auto &extra_data_io : extra_data_ios) {
+    data_ios.push_back(&extra_data_io);
+  }
+
+  int r = for_entry_in_inode_file([&](uint64_t ino) -> int {
+    int ret = scan_extent_for_inode(ino, data_ios);
+    if (ret < 0) {
+      std::cerr << "Failed targeted extent scan for inode 0x" << std::hex << ino
+                << std::dec << ": " << cpp_strerror(ret) << std::endl;
+    }
+    return ret;
+  });
+
+  return r;
+}
+
+int DataScan::scan_inodes_for_damage_file() {
+  bool roots_present;
+  int r = driver->check_roots(&roots_present);
+  if (r != 0) {
+    derr << "Unexpected error checking roots: '" << cpp_strerror(r) << "'"
+         << dendl;
+    return r;
+  }
+
+  if (!roots_present) {
+    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
+                 "one node before running 'scan_inodes'"
+              << std::endl;
+    return -EIO;
+  }
+
+  r = for_entry_in_damage_file([&](uint64_t ino) -> int {
+    inodeno_t selected_ino = static_cast<inodeno_t>(ino);
+    const std::string oid = format_extent_oid(selected_ino, 0);
+    int ret =
+        scan_inode_from_oid(oid, selected_ino, 0, force_restore_all_ancestors);
+    if (r < 0) {
+      std::cerr << "Failed targeted inode scan for inode 0x" << std::hex << ino
+                << std::dec << ": " << cpp_strerror(r) << std::endl;
+    }
+    return ret;
+  });
+  return r;
+}
+
+int DataScan::scan_inodes_for_inode_file() {
+  bool roots_present;
+  int r = driver->check_roots(&roots_present);
+  if (r != 0) {
+    derr << "Unexpected error checking roots: '" << cpp_strerror(r) << "'"
+         << dendl;
+    return r;
+  }
+
+  if (!roots_present) {
+    std::cerr << "Some or all system inodes are absent.  Run 'init' from "
+                 "one node before running 'scan_inodes'"
+              << std::endl;
+    return -EIO;
+  }
+
+  r = for_entry_in_inode_file([&](uint64_t ino) -> int {
+    const std::string oid = format_extent_oid(ino, 0);
+    int ret = scan_inode_from_oid(oid, ino, 0, force_restore_all_ancestors);
+    if (ret < 0) {
+      std::cerr << "Failed targeted inode scan for inode 0x" << std::hex << ino
+                << std::dec << ": " << cpp_strerror(ret) << std::endl;
+    }
+    return ret;
+  });
+
+  return r;
 }
 
 int DataScan::probe_filter(librados::IoCtx &ioctx)

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -12,20 +12,26 @@
  *
  */
 
-#include "include/compat.h"
-#include "common/errno.h"
 #include "common/ceph_argparse.h"
-#include "common/strtol.h"
 #include "common/ceph_json.h"
+#include "common/errno.h"
+#include "common/strtol.h"
+#include "include/ceph_fs.h"
+#include "include/compat.h"
+#include "include/util.h"
 #include "json_spirit/json_spirit_error_position.h"
 #include "json_spirit/json_spirit_reader.h"
 #include <algorithm>
+#include <atomic>
 #include <cerrno>
+#include <condition_variable>
 #include <fstream>
+#include <functional>
 #include <limits>
+#include <mutex>
+#include <queue>
 #include <sstream>
-#include "include/util.h"
-#include "include/ceph_fs.h"
+#include <thread>
 
 #include "mds/CDentry.h"
 #include "mds/CInode.h"
@@ -46,6 +52,112 @@
 using namespace std;
 
 namespace {
+
+class DataScanThreadPool {
+public:
+  explicit DataScanThreadPool(size_t worker_count) {
+    worker_count = std::max<size_t>(worker_count, 1);
+    workers.reserve(worker_count);
+    max_queue_size = worker_count * 10;
+    for (size_t i = 0; i < worker_count; ++i) {
+      workers.emplace_back([this]() { worker_entry(); });
+    }
+  }
+
+  ~DataScanThreadPool() { shutdown(); }
+
+  bool submit(std::function<int()> task) {
+    std::unique_lock l(lock);
+    queue_has_space.wait(l, [this]() {
+      return (error < 0 || stopping || !accepting ||
+              tasks.size() < max_queue_size);
+    });
+    if (error < 0 || !accepting || stopping) {
+      return false;
+    }
+    tasks.push(std::move(task));
+    has_work.notify_one();
+    return true;
+  }
+
+  void wait_for_drain() {
+    std::unique_lock l(lock);
+    accepting = false;
+    drained.wait(l, [this]() { return tasks.empty() && running_tasks == 0; });
+    queue_has_space.notify_all();
+  }
+
+  void shutdown() {
+    {
+      std::lock_guard l(lock);
+      if (stopping) {
+        return;
+      }
+      accepting = false;
+      stopping = true;
+    }
+    queue_has_space.notify_all();
+    has_work.notify_all();
+    for (auto &worker : workers) {
+      if (worker.joinable()) {
+        worker.join();
+      }
+    }
+    workers.clear();
+  }
+  
+  int get_error() {
+    return error.load(std::memory_order_relaxed);
+  }
+
+private:
+  void worker_entry() {
+    while (true) {
+      std::function<int()> task;
+      bool do_run = true;
+      int r = 0;
+      {
+        std::unique_lock l(lock);
+        has_work.wait(
+            l, [this]() { return stopping || !tasks.empty(); });
+        if (stopping && tasks.empty()) {
+          return;
+        }
+        task = std::move(tasks.front());
+        tasks.pop();
+        queue_has_space.notify_one();
+        ++running_tasks;
+        do_run = (error == 0);
+      }
+      if (do_run) {
+        r = task();
+      }
+
+      {
+        std::lock_guard l(lock);
+        if (r < 0 && error == 0) {
+          error = r;
+        }
+        --running_tasks;
+        if (!accepting && tasks.empty() && running_tasks == 0) {
+          drained.notify_all();
+        }
+      }
+    }
+  }
+
+  std::mutex lock;
+  std::condition_variable has_work;
+  std::condition_variable drained;
+  std::condition_variable queue_has_space;
+  std::queue<std::function<int()>> tasks;
+  std::vector<std::thread> workers;
+  size_t max_queue_size = 1;
+  bool accepting = true;
+  bool stopping = false;
+  size_t running_tasks = 0;
+  std::atomic<int> error = 0;
+};
 
 std::string trim_whitespace(const std::string &value)
 {
@@ -93,13 +205,14 @@ void DataScan::usage() {
          "[--worker_n N --worker_m M] [--damage-file PATH] "
          "[--type 'TYPE|TYPE'] [--inode-file PATH] [<data pool name>]\n"
       << "  cephfs-data-scan pg_files <path> <pg id> [<pg id>...]\n"
-      << "  cephfs-data-scan scan_links\n"
+      << "  cephfs-data-scan scan_links [--thread-count N]\n"
       << "\n"
       << "    --force-corrupt: overrite apparently corrupt structures\n"
       << "    --force-init: write root inodes even if they exist\n"
       << "    --force-pool: use data pool even if it is not in FSMap\n"
       << "    --worker_m: Maximum number of workers\n"
       << "    --worker_n: Worker number, range 0-(worker_m-1)\n"
+      << "    --thread-count: Number of scan_links worker threads\n"
       << "    --force-create-head-inode: force flushing inode 0th object in "
          "targeted scan_extents even when no extents are found\n"
       << "    --force-restore-all-ancestors: force restoring all ancestor "
@@ -145,6 +258,14 @@ bool DataScan::parse_kwarg(
     driver = new LocalFileDriver(val, data_io);
     return true;
   } else if (arg == std::string("--worker_n")) {
+    if (command == "scan_links") {
+      std::cerr << "Option '--worker_n' is invalid with scan_links; "
+                   "use '--thread-count'"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+
     std::string err;
     int64_t worker_n = strict_strtoll(val.c_str(), 10, &err);
     if (!err.empty() || worker_n < 0 ||
@@ -156,6 +277,14 @@ bool DataScan::parse_kwarg(
     n = static_cast<uint32_t>(worker_n);
     return true;
   } else if (arg == std::string("--worker_m")) {
+    if (command == "scan_links") {
+      std::cerr << "Option '--worker_m' is invalid with scan_links; "
+                   "use '--thread-count'"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+
     std::string err;
     int64_t worker_m = strict_strtoll(val.c_str(), 10, &err);
     if (!err.empty() || worker_m <= 0 ||
@@ -165,6 +294,24 @@ bool DataScan::parse_kwarg(
       return false;
     }
     m = static_cast<uint32_t>(worker_m);
+    return true;
+  } else if (arg == std::string("--thread-count")) {
+    if (command != "scan_links") {
+      std::cerr << "Option '--thread-count' is only valid with scan_links"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+
+    std::string err;
+    int64_t thread_count = strict_strtoll(val.c_str(), 10, &err);
+    if (!err.empty() || thread_count <= 0 ||
+        thread_count > std::numeric_limits<uint32_t>::max()) {
+      std::cerr << "Invalid thread count '" << val << "'" << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+    scan_links_thread_count = static_cast<uint32_t>(thread_count);
     return true;
   } else if (arg == std::string("--filter-tag")) {
     filter_tag = val;
@@ -264,10 +411,8 @@ bool DataScan::parse_kwarg(
   }
 }
 
-int DataScan::parse_damage_type_expr(
-    const std::string &expr,
-    std::vector<std::string> *tokens)
-{
+int DataScan::parse_damage_type_expr(const std::string &expr,
+                                     std::vector<std::string> *tokens) {
   tokens->clear();
   std::string trimmed_expr = trim_whitespace(expr);
   if (trimmed_expr.empty()) {
@@ -1828,14 +1973,79 @@ int DataScan::scan_links()
   enum {
     SCAN_INOS = 1,
     CHECK_LINK,
+    REMOVE_DUP_DENTRIES,
+    FIX_BAD_NLINK,
+    FIX_INJECTED_DNFIRST,
   };
 
-  for (int step = SCAN_INOS; step <= CHECK_LINK; step++) {
-    const librados::NObjectIterator it_end = metadata_io.nobjects_end();
-    for (auto it = metadata_io.nobjects_begin(); it != it_end; ++it) {
-      const std::string oid = it->get_oid();
+  const size_t phase_workers = std::max<uint32_t>(1, scan_links_thread_count);
 
-      dout(10) << "step " << step << ": handling object " << oid << dendl;
+  auto run_phase = [phase_workers](auto &&schedule, bool use_strand) -> int {
+    std::unique_ptr<DataScanThreadPool> concurrent_runner =
+        std::make_unique<DataScanThreadPool>(phase_workers);
+    std::unique_ptr<DataScanThreadPool> strand_runner = nullptr;
+    if (use_strand) {
+      strand_runner = std::make_unique<DataScanThreadPool>(1);
+    }
+
+    int r = 0;
+    int schedule_r = schedule(concurrent_runner, strand_runner);
+    if (schedule_r < 0) {
+      r = schedule_r;
+    }
+
+    concurrent_runner->wait_for_drain();
+    int con_r = concurrent_runner->get_error();
+    if (r == 0 && con_r < 0) {
+      r = con_r;
+    }
+    if (use_strand)  {
+      strand_runner->wait_for_drain();
+      int str_r = strand_runner->get_error();
+      if (r == 0 && str_r < 0) {
+        r = str_r;
+      }
+    }
+    concurrent_runner->shutdown();
+    if (use_strand) {
+      strand_runner->shutdown();
+    }
+    return r;
+  };
+
+  auto scan_dirfrag_slice = [this, &used_inos, &remote_links,
+                             &dup_primaries, &bad_nlink_inos, &injected_inos,
+                             &to_remove, &snaps, &last_snap,
+                             &snaprealm_v2_since]
+                             (int step, size_t worker_id,
+                              size_t worker_count, 
+                              std::unique_ptr <DataScanThreadPool>& strand_runner) -> int {
+    librados::ObjectCursor range_i;
+    librados::ObjectCursor range_end;
+    metadata_io.object_list_slice(metadata_io.object_list_begin(),
+                                  metadata_io.object_list_end(), worker_id,
+                                  worker_count, &range_i, &range_end);
+
+    const bufferlist filter_bl;
+    bool success = true;
+    while (range_i < range_end && success) {
+      std::vector<librados::ObjectItem> result;
+      int r = metadata_io.object_list(range_i, range_end, 1, filter_bl, &result,
+                                      &range_i);
+      if (r < 0) {
+        derr << "Unexpected error listing objects: " << cpp_strerror(r)
+             << dendl;
+        return r;
+      }
+
+      for (const auto &item : result) {
+        if (!success) {
+          break;
+        }
+        const std::string &oid = item.oid;
+        // std::cout << "phase-->" << step << ", oid-->" << oid << std::endl;
+
+        dout(10) << "step " << step << ": handling object " << oid << dendl;
 
       uint64_t dir_ino = 0;
       uint64_t frag_id = 0;
@@ -1859,12 +2069,18 @@ int DataScan::scan_links()
 	derr << "Error getting omap from '" << oid << "': " << cpp_strerror(r) << dendl;
 	return r;
       }
-
+      auto strand_task = [&used_inos, &remote_links, &dup_primaries,
+                          &bad_nlink_inos, &injected_inos,
+                          &to_remove, &snaps, &last_snap,
+                          &snaprealm_v2_since, step = step,
+                          dir_ino = dir_ino, frag_id = frag_id,
+                          items = std::move(items)]() -> int {
       for (auto& p : items) {
 	auto q = p.second.cbegin();
 	string dname;
 	snapid_t last;
 	dentry_key_t::decode_helper(p.first, dname, last);
+  // std::cout << "phase-->" << step << ", dir_ino-->" << dir_ino << ", dname-->" << dname << std::endl;
 
 	if (last != CEPH_NOSNAP) {
 	  if (last > last_snap)
@@ -1985,7 +2201,54 @@ int DataScan::scan_links()
 	  return -EINVAL;
 	}
       }
+      return 0;
+    };
+    success = strand_runner->submit(strand_task);
     }
+  }
+    return 0;
+  };
+
+  // Phase 1: SCAN_INOS
+  // std::cout << "scan_inos-->" << std::endl;
+  dout(0) << "scanning inode dentries" << dendl;
+  int r = run_phase(
+      [phase_workers, &scan_dirfrag_slice](
+          std::unique_ptr<DataScanThreadPool> &concurrent_runner,
+          std::unique_ptr<DataScanThreadPool> &strand_runner) {
+        bool success = true;
+        for (size_t worker = 0; worker < phase_workers && success; ++worker) {
+          success = concurrent_runner->submit([&, worker]() {
+            return scan_dirfrag_slice(SCAN_INOS, worker, phase_workers,
+                                      strand_runner);
+          });
+        }
+        return 0;
+      },
+      true);
+  if (r < 0) {
+    return r;
+  }
+
+  // Phase 2: CHECK_LINK
+  // std::cout << "scan_links-->" << std::endl;
+  dout(0) << "scanning link dentries" << dendl;
+  r = run_phase(
+      [phase_workers, &scan_dirfrag_slice](
+          std::unique_ptr<DataScanThreadPool> &concurrent_runner,
+          std::unique_ptr<DataScanThreadPool> &strand_runner) {
+        bool success = true;
+        for (size_t worker = 0; worker < phase_workers && success; ++worker) {
+          success = concurrent_runner->submit([&, worker]() {
+            return scan_dirfrag_slice(CHECK_LINK, worker, phase_workers,
+                                      strand_runner);
+          });
+        }
+        return 0;
+      },
+      true);
+  if (r < 0) {
+    return r;
   }
 
   map<unsigned, uint64_t> max_ino_map;
@@ -2089,74 +2352,139 @@ int DataScan::scan_links()
     }
   }
 
-  dout(10) << "removing dup dentries from " << to_remove.size() << " objects"
+  dout(0) << "removing dup dentries from " << to_remove.size() << " objects"
 	   << dendl;
+  // std::cout << "remove_dup_dentries-->" << std::endl;
 
-  for (auto& p : to_remove) {
-    object_t frag_oid = InodeStore::get_object_name(p.first.ino, p.first.frag, "");
+  // Phase 3: REMOVE_DUP_DENTRIES
+  r = run_phase(
+      [this, &to_remove](std::unique_ptr<DataScanThreadPool> &concurrent_runner,
+                         std::unique_ptr<DataScanThreadPool> &strand_runner) {
+        bool success = true;
+        // std::cout << "to_remove.size()-->" << to_remove.size() << std::endl;
+        for (auto it = to_remove.begin(); it != to_remove.end() && success;
+             ++it) {
 
-    dout(10) << "removing dup dentries from " << p.first << dendl;
+          auto *p = &(*it);
+          success = concurrent_runner->submit([this, p]() {
+            // std::cout << "to_remove-->" << p->first.ino << ", frag-->"
+            //           << p->first.frag << std::endl;
+            object_t frag_oid =
+                InodeStore::get_object_name(p->first.ino, p->first.frag, "");
 
-    int r = metadata_io.omap_rm_keys(frag_oid.name, p.second);
-    if (r != 0) {
-      derr << "Error removing duplicated dentries from " << p.first << dendl;
-      return r;
-    }
+            dout(10) << "removing dup dentries from " << p->first << dendl;
+
+            int phase_r = metadata_io.omap_rm_keys(frag_oid.name, p->second);
+            if (phase_r != 0) {
+              derr << "Error removing duplicated dentries from " << p->first
+                   << dendl;
+            }
+            return phase_r;
+          });
+        }
+        return 0;
+      },
+      false);
+  if (r < 0) {
+    return r;
   }
   to_remove.clear();
 
-  dout(10) << "processing " << bad_nlink_inos.size() << " bad_nlink_inos"
-	   << dendl;
+  dout(0) << "processing " << bad_nlink_inos.size() << " bad_nlink_inos"
+           << dendl;
 
-  for (auto &p : bad_nlink_inos) {
-    dout(10) << "handling bad_nlink_ino " << p.first << dendl;
+  // Phase 4: FIX_BAD_NLINK
+  // std::cout << "fix_bad_nlink-->" << std::endl;
+  r = run_phase(
+      [this, &bad_nlink_inos,
+       &metadata_driver](std::unique_ptr<DataScanThreadPool> &concurrent_runner,
+                         std::unique_ptr<DataScanThreadPool> &strand_runner) {
+        bool success = true;
+        // std::cout << "bad_nlink_inos.size()-->" << bad_nlink_inos.size() << std::endl;
+        for (auto it = bad_nlink_inos.begin();
+             it != bad_nlink_inos.end() && success; ++it) {
 
-    InodeStore inode;
-    snapid_t first;
-    int r = read_dentry(p.second.dirino, p.second.frag, p.second.name, &inode, &first);
-    if (r < 0) {
-      derr << "Unexpected error reading dentry "
-	   << p.second.dirfrag() << "/" << p.second.name
-	   << ": " << cpp_strerror(r) << dendl;
-      return r;
-    }
+          auto *p = &(*it);
+          success = concurrent_runner->submit([this, &metadata_driver, p]() {
+            // std::cout << "bad_nlink_ino-->" << p->first << std::endl;
+            dout(10) << "handling bad_nlink_ino " << p->first << dendl;
 
-    if (inode.inode->ino != p.first || inode.inode->version != p.second.version)
-      continue;
+            InodeStore inode;
+            snapid_t first;
+            int phase_r = read_dentry(p->second.dirino, p->second.frag,
+                                      p->second.name, &inode, &first);
+            if (phase_r < 0) {
+              derr << "Unexpected error reading dentry " << p->second.dirfrag()
+                   << "/" << p->second.name << ": " << cpp_strerror(phase_r)
+                   << dendl;
+              return phase_r;
+            }
 
-    inode.get_inode()->nlink = p.second.nlink;
-    r = metadata_driver->inject_linkage(p.second.dirino, p.second.name, p.second.frag, inode, first);
-    if (r < 0)
-      return r;
+            if (inode.inode->ino != p->first ||
+                inode.inode->version != p->second.version) {
+              return 0;
+            }
+
+            inode.get_inode()->nlink = p->second.nlink;
+            return metadata_driver->inject_linkage(
+                p->second.dirino, p->second.name, p->second.frag, inode, first);
+          });
+        }
+        return 0;
+      },
+      false);
+  if (r < 0) {
+    return r;
   }
 
-  dout(10) << "processing " << injected_inos.size() << " injected_inos"
+  dout(0) << "processing " << injected_inos.size() << " injected_inos"
 	   << dendl;
 
-  for (auto &p : injected_inos) {
-    dout(10) << "handling injected_ino " << p.first << dendl;
+  // Phase 5: FIX_INJECTED_DNFIRST
+  // std::cout << "fix_injected_dnfirst" << std::endl;
+  r = run_phase(
+      [this, &injected_inos, &metadata_driver,
+       &last_snap](std::unique_ptr<DataScanThreadPool> &concurrent_runner,
+                   std::unique_ptr<DataScanThreadPool> &strand_runner) {
+        bool success = true;
+        // std::cout << "injected_inos.size()-->" << injected_inos.size() << std::endl;
+        for (auto it = injected_inos.begin();
+             it != injected_inos.end() && success; ++it) {
+          auto *p = &(*it);
+          success = concurrent_runner->submit([this, &last_snap,
+                                               &metadata_driver, p]() {
+            // std::cout << "injected_ino-->" << p->first << std::endl;
+            dout(10) << "handling injected_ino " << p->first << dendl;
 
-    InodeStore inode;
-    snapid_t first;
-    dout(20) << " fixing linkage (dnfirst) of " << p.second.dirino << ":" << p.second.name << dendl;
-    int r = read_dentry(p.second.dirino, p.second.frag, p.second.name, &inode, &first);
-    if (r < 0) {
-      derr << "Unexpected error reading dentry "
-	<< p.second.dirfrag() << "/" << p.second.name
-	<< ": " << cpp_strerror(r) << dendl;
-      continue;
-    }
+            InodeStore inode;
+            snapid_t first;
+            dout(20) << " fixing linkage (dnfirst) of " << p->second.dirino
+                     << ":" << p->second.name << dendl;
+            int phase_r = read_dentry(p->second.dirino, p->second.frag,
+                                      p->second.name, &inode, &first);
+            if (phase_r < 0) {
+              derr << "Unexpected error reading dentry " << p->second.dirfrag()
+                   << "/" << p->second.name << ": " << cpp_strerror(phase_r)
+                   << dendl;
+              return 0;
+            }
 
-    if (first != CEPH_NOSNAP) {
-      dout(20) << " ????" << dendl;
-      continue;
-    }
+            if (first != CEPH_NOSNAP) {
+              dout(20) << " ????" << dendl;
+              return 0;
+            }
 
-    first = last_snap + 1;
-    dout(20) << " first is now " << first << dendl;
-    r = metadata_driver->inject_linkage(p.second.dirino, p.second.name, p.second.frag, inode, first);
-    if (r < 0)
-      return r;
+            first = last_snap + 1;
+            dout(20) << " first is now " << first << dendl;
+            return metadata_driver->inject_linkage(
+                p->second.dirino, p->second.name, p->second.frag, inode, first);
+          });
+        }
+        return 0;
+      },
+      false);
+  if (r < 0) {
+    return r;
   }
 
   dout(10) << "updating inotable" << dendl;

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -15,7 +15,15 @@
 #include "include/compat.h"
 #include "common/errno.h"
 #include "common/ceph_argparse.h"
+#include "common/strtol.h"
+#include "common/ceph_json.h"
+#include "json_spirit/json_spirit_error_position.h"
+#include "json_spirit/json_spirit_reader.h"
+#include <algorithm>
+#include <cerrno>
 #include <fstream>
+#include <limits>
+#include <sstream>
 #include "include/util.h"
 #include "include/ceph_fs.h"
 
@@ -37,38 +45,88 @@
 
 using namespace std;
 
-void DataScan::usage()
+namespace {
+
+std::string trim_whitespace(const std::string &value)
 {
-  std::cout << "Usage: \n"
-    << "  cephfs-data-scan init [--force-init]\n"
-    << "  cephfs-data-scan scan_extents [--force-pool] [--worker_n N --worker_m M] [<data pool name> [<extra data pool name> ...]]\n"
-    << "  cephfs-data-scan scan_inodes [--force-pool] [--force-corrupt] [--worker_n N --worker_m M] [<data pool name>]\n"
-    << "  cephfs-data-scan pg_files <path> <pg id> [<pg id>...]\n"
-    << "  cephfs-data-scan scan_links\n"
-    << "\n"
-    << "    --force-corrupt: overrite apparently corrupt structures\n"
-    << "    --force-init: write root inodes even if they exist\n"
-    << "    --force-pool: use data pool even if it is not in FSMap\n"
-    << "    --worker_m: Maximum number of workers\n"
-    << "    --worker_n: Worker number, range 0-(worker_m-1)\n"
-    << "\n"
-    << "  cephfs-data-scan scan_frags [--force-corrupt]\n"
-    << "  cephfs-data-scan cleanup [<data pool name>]\n"
-    << std::endl;
+  static constexpr char whitespace[] = " \t\n\r\f\v";
+  size_t start = value.find_first_not_of(whitespace);
+  if (start == std::string::npos) {
+    return std::string();
+  }
+  size_t end = value.find_last_not_of(whitespace);
+  return value.substr(start, end - start + 1);
+}
+
+std::string describe_json_parse_error(const std::string &json_line)
+{
+  json_spirit::Value parsed;
+  try {
+    json_spirit::read_or_throw(json_line, parsed);
+  } catch (const json_spirit::Error_position &e) {
+    std::ostringstream oss;
+    oss << e.reason_ << " at column " << e.column_;
+    return oss.str();
+  } catch (const std::string &e) {
+    return e;
+  } catch (const std::exception &e) {
+    return e.what();
+  }
+
+  return "invalid JSON syntax";
+}
+
+}
+
+void DataScan::usage() {
+  std::cout
+      << "Usage: \n"
+      << "  cephfs-data-scan init [--force-init]\n"
+      << "  cephfs-data-scan scan_extents [--force-pool] "
+         "[--force-create-head-inode] [--worker_n N "
+         "--worker_m M] [--damage-file PATH] [--type 'TYPE|TYPE'] "
+         "[--inode-file PATH] [--extent-period N] [--extent-limit N] "
+         "[<data pool name> [<extra data pool "
+         "name> ...]]\n"
+      << "  cephfs-data-scan scan_inodes [--force-pool] [--force-corrupt] "
+         "[--worker_n N --worker_m M] [<data pool name>]\n"
+      << "  cephfs-data-scan pg_files <path> <pg id> [<pg id>...]\n"
+      << "  cephfs-data-scan scan_links\n"
+      << "\n"
+      << "    --force-corrupt: overrite apparently corrupt structures\n"
+      << "    --force-init: write root inodes even if they exist\n"
+      << "    --force-pool: use data pool even if it is not in FSMap\n"
+      << "    --worker_m: Maximum number of workers\n"
+      << "    --worker_n: Worker number, range 0-(worker_m-1)\n"
+      << "    --force-create-head-inode: force flushing inode 0th object in "
+         "targeted scan_extents even when no extents are found\n"
+      << "\n"
+      << "  cephfs-data-scan scan_frags [--force-corrupt]\n"
+      << "  cephfs-data-scan cleanup [<data pool name>]\n"
+      << std::endl;
 
   generic_client_usage();
 }
 
 bool DataScan::parse_kwarg(
+    const std::string &command,
     const std::vector<const char*> &args,
     std::vector<const char *>::const_iterator &i,
     int *r)
 {
+  const std::string arg(*i);
+
   if (i + 1 == args.end()) {
+    if (arg == std::string("--damage-file") || arg == std::string("--type") ||
+        arg == std::string("--inode-file") ||
+        arg == std::string("--extent-period") ||
+        arg == std::string("--extent-limit")) {
+      std::cerr << "Missing value for '" << arg << "'" << std::endl;
+      *r = -EINVAL;
+    }
     return false;
   }
 
-  const std::string arg(*i);
   const std::string val(*(i + 1));
 
   if (arg == std::string("--output-dir")) {
@@ -82,25 +140,103 @@ bool DataScan::parse_kwarg(
     return true;
   } else if (arg == std::string("--worker_n")) {
     std::string err;
-    n = strict_strtoll(val.c_str(), 10, &err);
-    if (!err.empty()) {
+    int64_t worker_n = strict_strtoll(val.c_str(), 10, &err);
+    if (!err.empty() || worker_n < 0 ||
+        worker_n > std::numeric_limits<uint32_t>::max()) {
       std::cerr << "Invalid worker number '" << val << "'" << std::endl;
       *r = -EINVAL;
       return false;
     }
+    n = static_cast<uint32_t>(worker_n);
     return true;
   } else if (arg == std::string("--worker_m")) {
     std::string err;
-    m = strict_strtoll(val.c_str(), 10, &err);
-    if (!err.empty()) {
+    int64_t worker_m = strict_strtoll(val.c_str(), 10, &err);
+    if (!err.empty() || worker_m <= 0 ||
+        worker_m > std::numeric_limits<uint32_t>::max()) {
       std::cerr << "Invalid worker count '" << val << "'" << std::endl;
       *r = -EINVAL;
       return false;
     }
+    m = static_cast<uint32_t>(worker_m);
     return true;
   } else if (arg == std::string("--filter-tag")) {
     filter_tag = val;
     dout(10) << "Applying tag filter: '" << filter_tag << "'" << dendl;
+    return true;
+  } else if (arg == std::string("--damage-file")) {
+    if (command != "scan_extents") {
+      std::cerr << "Option '--damage-file' is only valid with scan_extents"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+    damage_file_path = val;
+    return true;
+  } else if (arg == std::string("--type")) {
+    if (command != "scan_extents") {
+      std::cerr << "Option '--type' is only valid with scan_extents"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+
+    std::vector<std::string> tokens;
+    *r = parse_damage_type_expr(val, &tokens);
+    if (*r < 0) {
+      return false;
+    }
+    damage_type_expr = val;
+    damage_type_tokens = tokens;
+    damage_type_filter_set = true;
+    damage_type_all = false;
+    return true;
+  } else if (arg == std::string("--inode-file")) {
+    if (command != "scan_extents") {
+      std::cerr << "Option '--inode-file' is only valid with scan_extents"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+    inode_file_path = val;
+    return true;
+  } else if (arg == std::string("--extent-period")) {
+    if (command != "scan_extents") {
+      std::cerr << "Option '--extent-period' is only valid with scan_extents"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+
+    auto parsed_period = ceph::parse<uint64_t>(val);
+    if (!parsed_period || *parsed_period == 0) {
+      std::cerr << "Invalid extent period '" << val << "': must be >= 1"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+
+    extent_period = *parsed_period;
+    extent_period_set = true;
+    return true;
+  } else if (arg == std::string("--extent-limit")) {
+    if (command != "scan_extents") {
+      std::cerr << "Option '--extent-limit' is only valid with scan_extents"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+
+    auto parsed_limit = ceph::parse<uint64_t>(val);
+    if (!parsed_limit || *parsed_limit == 0) {
+      std::cerr << "Invalid extent limit '" << val << "': must be >= 1"
+                << std::endl;
+      *r = -EINVAL;
+      return false;
+    }
+
+    extent_limit = *parsed_limit;
+    extent_limit_set = true;
     return true;
   } else if (arg == std::string("--filesystem")) {
     std::shared_ptr<const Filesystem> fs;
@@ -119,6 +255,43 @@ bool DataScan::parse_kwarg(
   }
 }
 
+int DataScan::parse_damage_type_expr(
+    const std::string &expr,
+    std::vector<std::string> *tokens)
+{
+  tokens->clear();
+  std::string trimmed_expr = trim_whitespace(expr);
+  if (trimmed_expr.empty()) {
+    std::cerr << "Invalid --type expression: empty value" << std::endl;
+    return -EINVAL;
+  }
+
+  std::set<std::string> seen;
+  size_t start = 0;
+  while (start <= expr.size()) {
+    size_t sep = expr.find('|', start);
+    std::string raw = sep == std::string::npos
+      ? expr.substr(start)
+      : expr.substr(start, sep - start);
+    std::string token = trim_whitespace(raw);
+    if (token.empty()) {
+      std::cerr << "Invalid --type expression '" << expr
+                << "': empty token around '|'" << std::endl;
+      return -EINVAL;
+    }
+    if (seen.insert(token).second) {
+      tokens->push_back(token);
+    }
+
+    if (sep == std::string::npos) {
+      break;
+    }
+    start = sep + 1;
+  }
+
+  return 0;
+}
+
 bool DataScan::parse_arg(
     const std::vector<const char*> &args,
     std::vector<const char *>::const_iterator &i)
@@ -132,6 +305,9 @@ bool DataScan::parse_arg(
     return true;
   } else if (arg == "--force-init") {
     force_init = true;
+    return true;
+  } else if (arg == "--force-create-head-inode") {
+    force_create_head_inode = true;
     return true;
   } else {
     return false;
@@ -166,7 +342,7 @@ int DataScan::main(const std::vector<const char*> &args)
   // Consume any known --key val or --flag arguments
   for (std::vector<const char *>::const_iterator i = args.begin() + 1;
        i != args.end(); ++i) {
-    if (parse_kwarg(args, i, &r)) {
+    if (parse_kwarg(command, args, i, &r)) {
       // Skip the kwarg value field
       ++i;
       continue;
@@ -217,6 +393,63 @@ int DataScan::main(const std::vector<const char*> &args)
     // Fall through: unhandled
     std::cerr << "Unknown argument '" << *i << "'" << std::endl;
     return -EINVAL;
+  }
+
+  if (command != "scan_extents") {
+    if (!damage_file_path.empty()) {
+      std::cerr << "Option '--damage-file' is only valid with scan_extents"
+                << std::endl;
+      return -EINVAL;
+    }
+    if (damage_type_filter_set) {
+      std::cerr << "Option '--type' is only valid with scan_extents"
+                << std::endl;
+      return -EINVAL;
+    }
+    if (!inode_file_path.empty()) {
+      std::cerr << "Option '--inode-file' is only valid with scan_extents"
+                << std::endl;
+      return -EINVAL;
+    }
+    if (extent_period_set) {
+      std::cerr << "Option '--extent-period' is only valid with scan_extents"
+                << std::endl;
+      return -EINVAL;
+    }
+    if (extent_limit_set) {
+      std::cerr << "Option '--extent-limit' is only valid with scan_extents"
+                << std::endl;
+      return -EINVAL;
+    }
+    if (force_create_head_inode) {
+      std::cerr << "Option '--force-create-head-inode' is only valid with "
+                   "scan_extents"
+                << std::endl;
+      return -EINVAL;
+    }
+  }
+
+  if (command == "scan_extents" && (extent_period_set || extent_limit_set) &&
+      damage_file_path.empty() && inode_file_path.empty()) {
+    std::cerr << "Options '--extent-period'/'--extent-limit' require "
+                 "'--damage-file' or "
+                 "'--inode-file'"
+              << std::endl;
+    return -EINVAL;
+  }
+
+  if (command == "scan_extents" && force_create_head_inode &&
+      damage_file_path.empty() && inode_file_path.empty()) {
+    std::cerr << "Option '--force-create-head-inode' requires '--damage-file' "
+                 "or '--inode-file'"
+              << std::endl;
+    return -EINVAL;
+  }
+
+  if (command == "scan_extents" &&
+      !damage_file_path.empty() &&
+      !damage_type_filter_set) {
+    damage_type_all = true;
   }
 
   // If caller didn't specify a namespace, try to pick
@@ -382,6 +615,12 @@ int DataScan::main(const std::vector<const char*> &args)
   if (command == "scan_inodes") {
     return scan_inodes();
   } else if (command == "scan_extents") {
+    if (!damage_file_path.empty()) {
+      return scan_extents_for_damage_file();
+    }
+    if (!inode_file_path.empty()) {
+      return scan_extents_for_inode_file();
+    }
     return scan_extents();
   } else if (command == "scan_frags") {
     return scan_frags();
@@ -568,6 +807,96 @@ int parse_oid(const std::string &oid, uint64_t *inode_no, uint64_t *obj_id)
   return 0;
 }
 
+std::string format_extent_oid(inodeno_t ino, uint64_t extent_id) {
+  char buf[60];
+  snprintf(buf, sizeof(buf), "%llx.%08llx", (long long unsigned)ino,
+           (long long unsigned)extent_id);
+  return std::string(buf);
+}
+
+int DataScan::scan_extent_for_inode(
+    inodeno_t ino, const std::vector<librados::IoCtx *> &data_ios) {
+  ceph_assert(!data_ios.empty());
+
+  AccumulateResult accum_res;
+  bool found_extent = false;
+  uint64_t window_start = 0;
+  while (window_start < extent_limit) {
+    bool window_productive = false;
+    bool all_stat_failed = true;
+
+    uint64_t window_end = window_start + extent_period;
+    if (window_end < window_start || window_end > extent_limit) {
+      window_end = extent_limit;
+    }
+    for (uint64_t extent_id = window_start; extent_id < window_end;
+         ++extent_id) {
+      const std::string oid = format_extent_oid(ino, extent_id);
+
+      for (auto ioctx : data_ios) {
+        uint64_t size = 0;
+        time_t mtime = 0;
+        int r = ioctx->stat(oid, &size, &mtime);
+        if (r != 0) {
+          dout(20) << "Cannot stat '" << oid << "' in pool id "
+                   << ioctx->get_id() << ": " << cpp_strerror(r) << dendl;
+          continue;
+        }
+
+        all_stat_failed = false;
+        int64_t obj_pool_id =
+            data_io.get_id() != ioctx->get_id() ? ioctx->get_id() : -1;
+
+        r = ClsCephFSClient::accumulate_inode_metadata(data_io, ino, extent_id,
+                                                       size, obj_pool_id, mtime,
+                                                       &accum_res, false);
+        if (r < 0) {
+          derr << "Failed to accumulate metadata for inode 0x" << std::hex
+               << static_cast<uint64_t>(ino) << std::dec << " from '" << oid
+               << "': " << cpp_strerror(r) << dendl;
+          return r;
+        }
+
+        window_productive = true;
+        found_extent = true;
+      }
+    }
+
+    if (!window_productive && all_stat_failed) {
+      break;
+    }
+
+    window_start = window_end;
+  }
+
+  if (!found_extent) {
+    dout(10) << "No extents found for inode 0x" << std::hex
+             << static_cast<uint64_t>(ino) << std::dec << dendl;
+    if (!force_create_head_inode) {
+      dout(10) << "Skipping flush for inode 0x" << std::hex
+               << static_cast<uint64_t>(ino) << std::dec
+               << " because no extents were found and "
+                  "--force-create-head-inode is not set"
+               << dendl;
+      return 0;
+    }
+    dout(10) << "Forcing flush for inode 0x" << std::hex
+             << static_cast<uint64_t>(ino) << std::dec
+             << " despite no extents found because "
+                "--force-create-head-inode is set"
+             << dendl;
+  }
+
+  int r =
+      ClsCephFSClient::flush_inode_accumulate_result(data_io, ino, accum_res);
+  if (r < 0) {
+    derr << "Failed to flush accumulated metadata for inode 0x" << std::hex
+         << static_cast<uint64_t>(ino) << std::dec << ": " << cpp_strerror(r)
+         << dendl;
+  }
+
+  return r;
+}
 
 int DataScan::scan_extents()
 {
@@ -626,6 +955,185 @@ int DataScan::scan_extents()
     if (r < 0) {
       return r;
     }
+  }
+
+  return 0;
+}
+
+int DataScan::scan_extents_for_damage_file()
+{
+  if (m == 0) {
+    std::cerr << "Invalid worker count " << m << ": must be > 0" << std::endl;
+    return -EINVAL;
+  }
+  if (n >= m) {
+    std::cerr << "Invalid worker number " << n
+              << ": must be in range [0, " << (m - 1) << "]" << std::endl;
+    return -EINVAL;
+  }
+
+  std::ifstream input(damage_file_path);
+  if (!input.is_open()) {
+    int err = errno ? -errno : -ENOENT;
+    std::cerr << "Failed to open damage file '" << damage_file_path << "': "
+              << cpp_strerror(err) << std::endl;
+    return err;
+  }
+
+  std::vector<librados::IoCtx *> data_ios;
+  data_ios.push_back(&data_io);
+  for (auto &extra_data_io : extra_data_ios) {
+    data_ios.push_back(&extra_data_io);
+  }
+
+  uint64_t candidate_index = 0;
+  uint64_t line_no = 0;
+  std::string line;
+  while (std::getline(input, line)) {
+    ++line_no;
+    if (trim_whitespace(line).empty()) {
+      continue;
+    }
+
+    JSONParser parser;
+    if (!parser.parse(line.c_str(), static_cast<int>(line.size()))) {
+      std::cerr << "Invalid JSON on line " << line_no
+                << ": " << describe_json_parse_error(line)
+                << std::endl;
+      return -EINVAL;
+    }
+    if (!parser.is_object()) {
+      std::cerr << "Invalid damage entry on line " << line_no
+                << ": JSON value must be an object" << std::endl;
+      return -EINVAL;
+    }
+
+    std::string damage_type;
+    unsigned long long ino = 0;
+    try {
+      JSONDecoder::decode_json("damage_type", damage_type, &parser, true);
+      JSONDecoder::decode_json("ino", ino, &parser, true);
+    } catch (const JSONDecoder::err &e) {
+      std::cerr << "Invalid damage entry on line " << line_no
+                << ": " << e.what() << std::endl;
+      return -EINVAL;
+    }
+
+    JSONObj *damage_type_obj = parser.find_obj("damage_type");
+    ceph_assert(damage_type_obj != nullptr);
+    if (!damage_type_obj->get_data_val().quoted) {
+      std::cerr << "Invalid damage entry on line " << line_no
+                << ": damage_type must be a string" << std::endl;
+      return -EINVAL;
+    }
+
+    JSONObj *ino_obj = parser.find_obj("ino");
+    ceph_assert(ino_obj != nullptr);
+    if (ino_obj->get_data_val().quoted) {
+      std::cerr << "Invalid damage entry on line " << line_no
+                << ": ino must be a numeric JSON value" << std::endl;
+      return -EINVAL;
+    }
+
+    if (trim_whitespace(damage_type).empty()) {
+      std::cerr << "Invalid damage entry on line " << line_no
+                << ": damage_type must be a non-empty string" << std::endl;
+      return -EINVAL;
+    }
+
+    bool type_matched = damage_type_all;
+    if (!damage_type_all) {
+      type_matched = std::find(damage_type_tokens.begin(),
+                               damage_type_tokens.end(),
+                               damage_type) != damage_type_tokens.end();
+    }
+    if (!type_matched) {
+      continue;
+    }
+
+    if ((candidate_index % m) == n) {
+      dout(10) << "selected damage entry line=" << line_no
+               << " damage_type='" << damage_type << "'"
+               << " ino=0x" << std::hex << ino << std::dec
+               << " candidate_index=" << candidate_index
+               << " worker=" << n << "/" << m << dendl;
+
+      int r = scan_extent_for_inode(static_cast<inodeno_t>(ino), data_ios);
+      if (r < 0) {
+        std::cerr << "Failed targeted extent scan for inode 0x" << std::hex
+                  << ino << std::dec << ": " << cpp_strerror(r) << std::endl;
+        return r;
+      }
+    }
+
+    ++candidate_index;
+  }
+
+  return 0;
+}
+
+int DataScan::scan_extents_for_inode_file()
+{
+  if (m == 0) {
+    std::cerr << "Invalid worker count " << m << ": must be > 0" << std::endl;
+    return -EINVAL;
+  }
+  if (n >= m) {
+    std::cerr << "Invalid worker number " << n
+              << ": must be in range [0, " << (m - 1) << "]" << std::endl;
+    return -EINVAL;
+  }
+
+  std::ifstream input(inode_file_path);
+  if (!input.is_open()) {
+    int err = errno ? -errno : -ENOENT;
+    std::cerr << "Failed to open inode file '" << inode_file_path << "': "
+              << cpp_strerror(err) << std::endl;
+    return err;
+  }
+
+  std::vector<librados::IoCtx *> data_ios;
+  data_ios.push_back(&data_io);
+  for (auto &extra_data_io : extra_data_ios) {
+    data_ios.push_back(&extra_data_io);
+  }
+
+  uint64_t candidate_index = 0;
+  uint64_t line_no = 0;
+  std::string line;
+  while (std::getline(input, line)) {
+    ++line_no;
+
+    std::string trimmed = trim_whitespace(line);
+    if (trimmed.empty()) {
+      continue;
+    }
+
+    auto ino_val = ceph::parse<uint64_t>(trimmed);
+    if (!ino_val) {
+      std::cerr << "Invalid inode entry on line " << line_no
+                << ": expected unsigned integer inode" << std::endl;
+      return -EINVAL;
+    }
+    inodeno_t ino(*ino_val);
+
+    if ((candidate_index % m) == n) {
+      dout(10) << "selected inode entry line=" << line_no
+               << " ino=0x" << std::hex
+               << static_cast<uint64_t>(ino) << std::dec
+               << " candidate_index=" << candidate_index
+               << " worker=" << n << "/" << m << dendl;
+
+      int r = scan_extent_for_inode(ino, data_ios);
+      if (r < 0) {
+        std::cerr << "Failed targeted extent scan for inode 0x" << std::hex
+                  << static_cast<uint64_t>(ino) << std::dec << ": "
+                  << cpp_strerror(r) << std::endl;
+        return r;
+      }
+    }
+
+    ++candidate_index;
   }
 
   return 0;
@@ -2401,4 +2909,3 @@ void MetadataTool::build_dir_dentry(
   inode->uid = g_conf()->mds_root_ino_uid;
   inode->gid = g_conf()->mds_root_ino_gid;
 }
-

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -2028,6 +2028,16 @@ int DataScan::scan_links()
 	newest = q;
       }
     }
+    auto injected_it = injected_inos.find(p.first);
+    if (injected_it != injected_inos.end()) {
+      if (injected_it->second.dirino != newest.dirino ||
+          injected_it->second.name != newest.name) {
+        dout(10) << "Removing ino=" << p.first
+                 << "from injected_inos as they will be removed anyway"
+                 << dendl;
+        injected_inos.erase(injected_it);
+      }
+    }
 
     for (auto& q : p.second) {
       // in the middle of dir fragmentation?
@@ -2134,7 +2144,7 @@ int DataScan::scan_links()
       derr << "Unexpected error reading dentry "
 	<< p.second.dirfrag() << "/" << p.second.name
 	<< ": " << cpp_strerror(r) << dendl;
-      return r;
+      continue;
     }
 
     if (first != CEPH_NOSNAP) {

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -269,6 +269,24 @@ class DataScan : public MDSUtility, public MetadataTool
     int scan_extents();
 
     /**
+     * Scan damage entries from a line-delimited JSON input file and apply
+     * candidate-index worker slicing.
+     */
+    int scan_extents_for_damage_file();
+
+    /**
+     * Scan inode entries from a line-delimited input file and apply
+     * candidate-index worker slicing.
+     */
+    int scan_extents_for_inode_file();
+
+    /**
+     * Targeted extent scan for one inode using extent windows.
+     */
+    int scan_extent_for_inode(inodeno_t ino,
+                              const std::vector<librados::IoCtx *> &data_ios);
+
+    /**
      * Scan metadata pool for 0th dirfrags to link orphaned
      * directory inodes.
      */
@@ -296,11 +314,28 @@ class DataScan : public MDSUtility, public MetadataTool
     // Only scan inodes without this scrub tag
     std::string filter_tag;
 
+    // Parser state for scan_extents damage/inode inputs.
+    std::string damage_file_path;
+    std::string damage_type_expr;
+    std::vector<std::string> damage_type_tokens;
+    bool damage_type_filter_set;
+    bool damage_type_all;
+    std::string inode_file_path;
+    uint64_t extent_period;
+    bool extent_period_set;
+    uint64_t extent_limit;
+    bool extent_limit_set;
+    bool force_create_head_inode;
+
+    int parse_damage_type_expr(const std::string &expr,
+                               std::vector<std::string> *tokens);
+
     /**
      * @param r set to error on valid key with invalid value
      * @return true if argument consumed, else false
      */
     bool parse_kwarg(
+        const std::string &command,
         const std::vector<const char*> &args,
         std::vector<const char *>::const_iterator &i,
         int *r);
@@ -329,16 +364,14 @@ class DataScan : public MDSUtility, public MetadataTool
     int main(const std::vector<const char *> &args);
 
     DataScan()
-      : driver(NULL), fscid(FS_CLUSTER_ID_NONE),
-	data_pool_id(-1), n(0), m(1),
-        force_pool(false), force_corrupt(false),
-        force_init(false)
-    {
-    }
+        : driver(NULL), fscid(FS_CLUSTER_ID_NONE), data_pool_id(-1), n(0), m(1),
+          force_pool(false), force_corrupt(false), force_init(false),
+          damage_type_filter_set(false), damage_type_all(false),
+          extent_period(1), extent_period_set(false), extent_limit(1),
+          extent_limit_set(false), force_create_head_inode(false) {}
 
     ~DataScan() override
     {
       delete driver;
     }
 };
-

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -267,6 +267,7 @@ class DataScan : public MDSUtility, public MetadataTool
 
     uint32_t n;
     uint32_t m;
+    uint32_t scan_links_thread_count;
 
     /**
      * Scan data pool for backtraces, and inject inodes to metadata pool
@@ -404,11 +405,11 @@ class DataScan : public MDSUtility, public MetadataTool
 
     DataScan()
         : driver(NULL), fscid(FS_CLUSTER_ID_NONE), data_pool_id(-1), n(0), m(1),
-          force_pool(false), force_corrupt(false), force_init(false),
-          damage_type_filter_set(false), damage_type_all(false),
-          extent_period(1), extent_period_set(false), extent_limit(1),
-          extent_limit_set(false), force_create_head_inode(false),
-          force_restore_all_ancestors(false) {}
+          scan_links_thread_count(1), force_pool(false), force_corrupt(false),
+          force_init(false), damage_type_filter_set(false),
+          damage_type_all(false), extent_period(1), extent_period_set(false),
+          extent_limit(1), extent_limit_set(false),
+          force_create_head_inode(false), force_restore_all_ancestors(false) {}
 
     ~DataScan() override
     {

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -12,13 +12,11 @@
  *
  */
 
-
 #include "MDSUtility.h"
 #include "include/rados/librados.hpp"
 
 class InodeStore;
 class MDSTable;
-
 class RecoveryDriver {
   protected:
     // If true, overwrite structures that generate decoding errors.
@@ -50,9 +48,11 @@ class RecoveryDriver {
      * Inject an inode + dentry parents into the metadata pool,
      * based on a backtrace recovered from the data pool
      */
-    virtual int inject_with_backtrace(
-        const inode_backtrace_t &bt,
-        const InodeStore &dentry) = 0;
+    virtual int inject_with_backtrace(const inode_backtrace_t &bt,
+                                      const InodeStore &dentry,
+                                      bool force_inject_ancestors = false,
+                                      std::unordered_set<uint64_t> &&inode_set =
+                                          std::unordered_set<uint64_t>()) = 0;
 
     /**
      * Inject an inode + dentry into the lost+found directory,
@@ -124,9 +124,11 @@ class LocalFileDriver : public RecoveryDriver
         const FSMap *fsmap,
         fs_cluster_id_t fscid) override;
 
-    int inject_with_backtrace(
-        const inode_backtrace_t &bt,
-        const InodeStore &dentry) override;
+    int inject_with_backtrace(const inode_backtrace_t &bt,
+                              const InodeStore &dentry,
+                              bool force_inject_ancestors = false,
+                              std::unordered_set<uint64_t> &&inode_set =
+                                  std::unordered_set<uint64_t>()) override;
 
     int inject_lost_and_found(
         inodeno_t ino,
@@ -178,11 +180,16 @@ class MetadataTool
 		  const std::string &dname, InodeStore *inode, snapid_t *dnfirst=nullptr);
 };
 
+class DataScan; // forward declaration for friend declaration in RecoveryDriver
+
 /**
  * A class that knows how to manipulate CephFS metadata pools
  */
 class MetadataDriver : public RecoveryDriver, public MetadataTool
 {
+  public:
+    MetadataDriver(DataScan *dscan) : RecoveryDriver(), dscan(dscan) {}
+
   protected:
     /**
      * Create a .inode object, i.e. root or mydir
@@ -223,9 +230,11 @@ class MetadataDriver : public RecoveryDriver, public MetadataTool
         inodeno_t dir_ino, const std::string &dname,
         const frag_t fragment, const InodeStore &inode, snapid_t dnfirst=CEPH_NOSNAP);
 
-    int inject_with_backtrace(
-        const inode_backtrace_t &bt,
-        const InodeStore &dentry) override;
+    int inject_with_backtrace(const inode_backtrace_t &bt,
+                              const InodeStore &dentry,
+                              bool force_inject_ancestors = false,
+                              std::unordered_set<uint64_t> &&inode_set =
+                                  std::unordered_set<uint64_t>()) override;
 
     int inject_lost_and_found(
         inodeno_t ino,
@@ -237,6 +246,7 @@ class MetadataDriver : public RecoveryDriver, public MetadataTool
 
     int load_table(MDSTable *table);
     int save_table(MDSTable *table);
+    DataScan* dscan;
 };
 
 class DataScan : public MDSUtility, public MetadataTool
@@ -262,6 +272,23 @@ class DataScan : public MDSUtility, public MetadataTool
      * Scan data pool for backtraces, and inject inodes to metadata pool
      */
     int scan_inodes();
+
+    /**
+     * Recover and inject one inode from its 0th object oid.
+     */
+    int scan_inode_from_oid(const std::string &oid, uint64_t obj_name_ino,
+                            uint64_t obj_name_offset,
+                            bool force_restore_ancestors = false);
+
+    /**
+     * Targeted inode scan using line-delimited damage JSON input.
+     */
+    int scan_inodes_for_damage_file();
+
+    /**
+     * Targeted inode scan using line-delimited inode number input.
+     */
+    int scan_inodes_for_inode_file();
 
     /**
      * Scan data pool for file sizes and mtimes
@@ -291,6 +318,16 @@ class DataScan : public MDSUtility, public MetadataTool
      * directory inodes.
      */
     int scan_frags();
+
+    /**
+     * Scan metadata pool for 0th dirfrags to link orphaned
+     * directory for given oid of object.
+     */
+    int scan_frag_from_oid(const std::string &oid, uint64_t obj_name_ino,
+                           uint64_t obj_name_offset,
+                           bool force_restore_ancestors = false,
+                           std::unordered_set<uint64_t> &&inode_set =
+                               std::unordered_set<uint64_t>());
 
     /**
      * Cleanup xattrs from data pool
@@ -326,6 +363,7 @@ class DataScan : public MDSUtility, public MetadataTool
     uint64_t extent_limit;
     bool extent_limit_set;
     bool force_create_head_inode;
+    bool force_restore_all_ancestors;
 
     int parse_damage_type_expr(const std::string &expr,
                                std::vector<std::string> *tokens);
@@ -362,13 +400,15 @@ class DataScan : public MDSUtility, public MetadataTool
   public:
     static void usage();
     int main(const std::vector<const char *> &args);
+    friend class MetadataDriver;
 
     DataScan()
         : driver(NULL), fscid(FS_CLUSTER_ID_NONE), data_pool_id(-1), n(0), m(1),
           force_pool(false), force_corrupt(false), force_init(false),
           damage_type_filter_set(false), damage_type_all(false),
           extent_period(1), extent_period_set(false), extent_limit(1),
-          extent_limit_set(false), force_create_head_inode(false) {}
+          extent_limit_set(false), force_create_head_inode(false),
+          force_restore_all_ancestors(false) {}
 
     ~DataScan() override
     {

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -249,6 +249,7 @@ class MetadataDriver : public RecoveryDriver, public MetadataTool
     DataScan* dscan;
 };
 
+class AccumulateResult;
 class DataScan : public MDSUtility, public MetadataTool
 {
   protected:
@@ -355,9 +356,7 @@ class DataScan : public MDSUtility, public MetadataTool
     // Parser state for scan_extents damage/inode inputs.
     std::string damage_file_path;
     std::string damage_type_expr;
-    std::vector<std::string> damage_type_tokens;
-    bool damage_type_filter_set;
-    bool damage_type_all;
+    std::set<std::string> damage_type_tokens;
     std::string inode_file_path;
     uint64_t extent_period;
     bool extent_period_set;
@@ -367,7 +366,7 @@ class DataScan : public MDSUtility, public MetadataTool
     bool force_restore_all_ancestors;
 
     int parse_damage_type_expr(const std::string &expr,
-                               std::vector<std::string> *tokens);
+                               std::set<std::string> *tokens);
 
     /**
      * @param r set to error on valid key with invalid value
@@ -398,6 +397,14 @@ class DataScan : public MDSUtility, public MetadataTool
         bool untagged_only,
         std::function<int(std::string, uint64_t, uint64_t)> handler);
 
+    int for_entry_in_damage_file(std::function<int(uint64_t)> handler);
+    int for_entry_in_inode_file(std::function<int(uint64_t)> handler);
+    void update_accumulate_result(AccumulateResult *accum_res,
+                                  const uint64_t obj_index,
+                                  const uint64_t obj_size,
+                                  const int64_t obj_pool_id,
+                                  const time_t mtime);
+
   public:
     static void usage();
     int main(const std::vector<const char *> &args);
@@ -406,8 +413,7 @@ class DataScan : public MDSUtility, public MetadataTool
     DataScan()
         : driver(NULL), fscid(FS_CLUSTER_ID_NONE), data_pool_id(-1), n(0), m(1),
           scan_links_thread_count(1), force_pool(false), force_corrupt(false),
-          force_init(false), damage_type_filter_set(false),
-          damage_type_all(false), extent_period(1), extent_period_set(false),
+          force_init(false), extent_period(1), extent_period_set(false),
           extent_limit(1), extent_limit_set(false),
           force_create_head_inode(false), force_restore_all_ancestors(false) {}
 


### PR DESCRIPTION
1. remote link damage identification with reverse parent scrubbing
   - remote link identification becomes tricky if inode is cached.
   - Try to open the link normally, if issue while opening mark as damaged
   - If openned successfully, it can be possible there is damage but inode
     is cached that's why it is succssful while opening. In that case take
     that openned inode, and scrub ancestors recursively. If any of the ancestor
     is damaged it remote link is marked as damaged.
   - while scrubbing some flag is maintained in the inode,
     e.g. whether scrub is backward or forward or both
   - his backward scrubbing will only work in read-only scrub that means
     without repair flag and mds_scrub_hard_link this ceph flag is turned on.
   - A new type of damage introduced, using which multiple links point to same
     inode can be identified, which was not possible previously.
2. mds_damage_log_to_file and mds_damage_log_file is used to print out damages
   in a file persistently as it's not safe to keep it in memory

<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "quincy"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

- When filling out the below checklist, you may click boxes directly in the GitHub web UI.  When entering or editing the entire PR message in the GitHub web UI editor, you may also select a checklist item by adding an `x` between the brackets: `[x]`.  Spaces and capitalization matter when checking off items this way.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [x] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins test classic perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-classic/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test crimson perf` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-perf-crimson/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-perf-pull-requests/config/definitions/ceph-perf-pull-requests.yml)
- `jenkins test signed` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pr-commits/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-commits/config/definitions/ceph-pr-commits.yml)
- `jenkins test make check` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests/config/definitions/ceph-pull-requests.yml)
- `jenkins test make check arm64` [Jenkins Job](https://jenkins.ceph.com/job/ceph-pull-requests-arm64/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pull-requests-arm64/config/definitions/ceph-pull-requests-arm64.yml)
- `jenkins test submodules` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-pr-submodules/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-submodules/config/definitions/ceph-pr-commits.yml)
- `jenkins test dashboard` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-pull-requests/config/definitions/ceph-dashboard-pull-requests.yml)
- `jenkins test dashboard cephadm` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-dashboard-cephadm-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-dashboard-cephadm-e2e/config/definitions/ceph-dashboard-cephadm-e2e.yml)
- `jenkins test api` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-api/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-pr-api/config/definitions/ceph-pr-api.yml)
- `jenkins test docs` [ReadTheDocs](https://readthedocs.org/projects/ceph/) | [Github Workflow Definition](https://github.com/ceph/ceph/blob/main/.readthedocs.yml)
- `jenkins test ceph-volume all` [Jenkins Jobs](https://jenkins.ceph.com/view/ceph-volume%20PR/) | [Jenkins Jobs Definition](https://github.com/ceph/ceph-build/blob/main/ceph-volume-cephadm-prs/config/definitions/ceph-volume-pr.yml)
- `jenkins test windows` [Jenkins Job](https://jenkins.ceph.com/job/ceph-windows-pull-requests/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-windows-pull-requests/config/definitions/ceph-windows-pull-requests.yml)
- `jenkins test rook e2e` [Jenkins Job](https://jenkins.ceph.com/view/all/job/ceph-orchestrator-rook-e2e/) | [Jenkins Job Definition](https://github.com/ceph/ceph-build/blob/main/ceph-rook-e2e/config/definitions/ceph-orchestrator-rook-e2e.yml)

You must only issue one Jenkins command per-comment. Jenkins does not understand
comments with more than one command.
</details>
